### PR TITLE
Sync frontend nginx upload limit from MAX_UPLOAD_SIZE_MB env var.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,6 +101,8 @@ services:
       dockerfile: Dockerfile
     ports:
       - "3000:3000"
+    env_file:
+      - .env
     depends_on:
       - backend
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -9,6 +9,6 @@ RUN npm run build
 # Production stage
 FROM nginx:alpine
 COPY --from=build /app/dist /usr/share/nginx/html
-COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY nginx.conf.template /etc/nginx/templates/default.conf.template
 EXPOSE 3000
 CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/nginx.conf.template
+++ b/frontend/nginx.conf.template
@@ -3,7 +3,7 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
-    client_max_body_size 500M;
+    client_max_body_size ${MAX_UPLOAD_SIZE_MB}M;
 
     location /api/ {
         proxy_pass http://backend:8000;


### PR DESCRIPTION
  Replace static nginx.conf with a template processed by envsubst at
  startup, so client_max_body_size stays in sync with MAX_UPLOAD_SIZE_MB
  from .env rather than being hardcoded.