### PR TITLE
 Emulation session management improvements

### DIFF
--- a/backend/alembic/versions/b1c2d3e4f5a6_add_logs_to_emulation_sessions.py
+++ b/backend/alembic/versions/b1c2d3e4f5a6_add_logs_to_emulation_sessions.py
@@ -1,0 +1,26 @@
+"""add logs to emulation sessions
+
+Revision ID: b1c2d3e4f5a6
+Revises: f6a7b8c9d0e1
+Create Date: 2026-03-16 10:41:14.995621
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "b1c2d3e4f5a6"
+down_revision: Union[str, None] = "f6a7b8c9d0e1"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("emulation_sessions", sa.Column("logs", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("emulation_sessions", "logs")

--- a/backend/alembic/versions/c4d5e6f7a8b9_add_logs_to_emulation_sessions.py
+++ b/backend/alembic/versions/c4d5e6f7a8b9_add_logs_to_emulation_sessions.py
@@ -1,6 +1,6 @@
 """add logs to emulation sessions
 
-Revision ID: b1c2d3e4f5a6
+Revision ID: c4d5e6f7a8b9
 Revises: f6a7b8c9d0e1
 Create Date: 2026-03-16 10:41:14.995621
 
@@ -12,7 +12,7 @@ import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.
-revision: str = "b1c2d3e4f5a6"
+revision: str = "c4d5e6f7a8b9"
 down_revision: Union[str, None] = "f6a7b8c9d0e1"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None

--- a/backend/app/models/emulation_session.py
+++ b/backend/app/models/emulation_session.py
@@ -36,6 +36,7 @@ class EmulationSession(Base):
     container_id: Mapped[str | None] = mapped_column(String(100))
     pid: Mapped[int | None] = mapped_column(Integer)
     error_message: Mapped[str | None] = mapped_column(Text)
+    logs: Mapped[str | None] = mapped_column(Text)
     started_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     stopped_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     created_at: Mapped[datetime] = mapped_column(

--- a/backend/app/routers/emulation.py
+++ b/backend/app/routers/emulation.py
@@ -79,6 +79,21 @@ async def start_emulation(
     return session
 
 
+@router.delete("/{session_id}", status_code=204)
+async def delete_session(
+    project_id: uuid.UUID,
+    session_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+):
+    """Delete a stopped or errored emulation session."""
+    svc = EmulationService(db)
+    try:
+        await svc.delete_session(session_id)
+        await db.commit()
+    except ValueError as exc:
+        raise HTTPException(400, str(exc))
+
+
 @router.post(
     "/{session_id}/stop",
     response_model=EmulationSessionResponse,

--- a/backend/app/schemas/emulation.py
+++ b/backend/app/schemas/emulation.py
@@ -34,6 +34,7 @@ class EmulationSessionResponse(BaseModel):
     arguments: str | None
     port_forwards: list[dict] | None
     error_message: str | None
+    logs: str | None
     started_at: datetime | None
     stopped_at: datetime | None
     created_at: datetime

--- a/backend/app/services/emulation_service.py
+++ b/backend/app/services/emulation_service.py
@@ -1328,6 +1328,7 @@ echo "[wairz] Starting firmware init..."
             try:
                 client = self._get_docker_client()
                 container = client.containers.get(session.container_id)
+                session.logs = self._read_container_qemu_log(container, max_bytes=8000)
                 container.stop(timeout=5)
                 container.remove(force=True)
             except docker.errors.NotFound:
@@ -1590,7 +1591,9 @@ echo "[wairz] Starting firmware init..."
             container = client.containers.get(session.container_id)
             return self._read_container_qemu_log(container, max_bytes=8000)
         except docker.errors.NotFound:
-            # Container removed — return stored error_message
+            # Container removed — return saved logs or error_message
+            if session.logs:
+                return session.logs
             if session.error_message:
                 return session.error_message
             return "Container has been removed — no logs available."

--- a/backend/app/services/emulation_service.py
+++ b/backend/app/services/emulation_service.py
@@ -1340,6 +1340,19 @@ echo "[wairz] Starting firmware init..."
         await self.db.flush()
         return session
 
+    async def delete_session(self, session_id: UUID) -> None:
+        """Delete a stopped or errored emulation session record."""
+        result = await self.db.execute(
+            select(EmulationSession).where(EmulationSession.id == session_id)
+        )
+        session = result.scalar_one_or_none()
+        if not session:
+            raise ValueError("Session not found")
+        if session.status in ("running", "starting"):
+            raise ValueError("Cannot delete an active session — stop it first")
+        await self.db.delete(session)
+        await self.db.flush()
+
     async def exec_command(
         self,
         session_id: UUID,

--- a/frontend/src/api/emulation.ts
+++ b/frontend/src/api/emulation.ts
@@ -19,6 +19,13 @@ export async function startEmulation(
   return data
 }
 
+export async function deleteSession(
+  projectId: string,
+  sessionId: string,
+): Promise<void> {
+  await apiClient.delete(`/projects/${projectId}/emulation/${sessionId}`)
+}
+
 export async function stopEmulation(
   projectId: string,
   sessionId: string,

--- a/frontend/src/pages/EmulationPage.tsx
+++ b/frontend/src/pages/EmulationPage.tsx
@@ -25,6 +25,7 @@ import { formatDate } from '@/utils/format'
 import {
   startEmulation,
   stopEmulation,
+  deleteSession,
   listSessions,
   getSessionStatus,
   getSessionLogs,
@@ -196,6 +197,16 @@ export default function EmulationPage() {
       }
     } finally {
       setStarting(false)
+    }
+  }
+
+  const handleDismiss = async (sessionId: string) => {
+    if (!projectId) return
+    try {
+      await deleteSession(projectId, sessionId)
+      setSessions((prev) => prev.filter((s) => s.id !== sessionId))
+    } catch {
+      // ignore
     }
   }
 
@@ -624,6 +635,7 @@ export default function EmulationPage() {
                 projectId={projectId!}
                 onConnect={() => handleConnect(session)}
                 onStop={() => handleStop(session.id)}
+                onDismiss={() => handleDismiss(session.id)}
               />
             ))}
           </div>
@@ -663,9 +675,10 @@ interface SessionCardProps {
   projectId: string
   onConnect: () => void
   onStop: () => void
+  onDismiss: () => void
 }
 
-function SessionCard({ session, isActive, projectId, onConnect, onStop }: SessionCardProps) {
+function SessionCard({ session, isActive, projectId, onConnect, onStop, onDismiss }: SessionCardProps) {
   const statusCfg = STATUS_CONFIG[session.status] || STATUS_CONFIG.stopped
   const [showLogs, setShowLogs] = useState(false)
   const [logs, setLogs] = useState<string | null>(null)
@@ -705,11 +718,22 @@ function SessionCard({ session, isActive, projectId, onConnect, onStop }: Sessio
             {session.mode === 'user' ? 'User' : 'System'} Mode
           </span>
         </div>
-        {session.architecture && (
-          <Badge variant="outline" className="text-[10px]">
-            {session.architecture}
-          </Badge>
-        )}
+        <div className="flex items-center gap-2">
+          {session.architecture && (
+            <Badge variant="outline" className="text-[10px]">
+              {session.architecture}
+            </Badge>
+          )}
+          {(session.status === 'stopped' || session.status === 'error') && (
+            <button
+              onClick={onDismiss}
+              className="text-muted-foreground hover:text-destructive transition-colors"
+              title="Delete session"
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+            </button>
+          )}
+        </div>
       </div>
 
       {session.binary_path && (

--- a/frontend/src/pages/EmulationPage.tsx
+++ b/frontend/src/pages/EmulationPage.tsx
@@ -688,6 +688,16 @@ function SessionCard({ session, isActive, projectId, onConnect, onStop, onDismis
   const [logs, setLogs] = useState<string | null>(null)
   const [logsLoading, setLogsLoading] = useState(false)
 
+  // When the session finishes stopping, refresh logs if the panel is open
+  useEffect(() => {
+    if (session.status !== 'stopped' || !showLogs) return
+    setLogsLoading(true)
+    getSessionLogs(projectId, session.id)
+      .then(setLogs)
+      .catch(() => setLogs('Failed to fetch logs'))
+      .finally(() => setLogsLoading(false))
+  }, [session.status]) // eslint-disable-line react-hooks/exhaustive-deps
+
   const handleViewLogs = async () => {
     if (showLogs) {
       setShowLogs(false)

--- a/frontend/src/pages/EmulationPage.tsx
+++ b/frontend/src/pages/EmulationPage.tsx
@@ -624,14 +624,14 @@ export default function EmulationPage() {
           {/* Session list */}
           <div className="space-y-3">
             <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
-              Sessions ({sessions.length})
+              Sessions ({sessions.filter((s) => s.mode === mode).length})
             </h2>
 
-            {sessions.length === 0 && (
-              <p className="text-xs text-muted-foreground/60">No emulation sessions yet</p>
+            {sessions.filter((s) => s.mode === mode).length === 0 && (
+              <p className="text-xs text-muted-foreground/60">No {mode}-mode sessions yet</p>
             )}
 
-            {sessions.map((session) => (
+            {sessions.filter((s) => s.mode === mode).map((session) => (
               <SessionCard
                 key={session.id}
                 session={session}

--- a/frontend/src/pages/EmulationPage.tsx
+++ b/frontend/src/pages/EmulationPage.tsx
@@ -50,6 +50,7 @@ const STATUS_CONFIG: Record<EmulationStatus, { label: string; className: string 
   created: { label: 'Created', className: 'bg-gray-500 text-white' },
   starting: { label: 'Starting', className: 'bg-yellow-500 text-black' },
   running: { label: 'Running', className: 'bg-green-500 text-white' },
+  stopping: { label: 'Stopping...', className: 'bg-orange-500 text-white' },
   stopped: { label: 'Stopped', className: 'bg-zinc-600 text-white' },
   error: { label: 'Error', className: 'bg-red-500 text-white' },
 }
@@ -212,15 +213,18 @@ export default function EmulationPage() {
 
   const handleStop = async (sessionId: string) => {
     if (!projectId) return
+    setSessions((prev) =>
+      prev.map((s) => (s.id === sessionId ? { ...s, status: 'stopping' as const } : s))
+    )
+    if (activeSession?.id === sessionId) {
+      setShowTerminal(false)
+      setActiveSession(null)
+    }
     try {
-      await stopEmulation(projectId, sessionId)
-      if (activeSession?.id === sessionId) {
-        setShowTerminal(false)
-        setActiveSession(null)
-      }
-      await loadSessions()
+      const updated = await stopEmulation(projectId, sessionId)
+      setSessions((prev) => prev.map((s) => (s.id === sessionId ? updated : s)))
     } catch {
-      // ignore
+      await loadSessions()
     }
   }
 
@@ -747,8 +751,8 @@ function SessionCard({ session, isActive, projectId, onConnect, onStop, onDismis
         {formatDate(session.created_at)}
       </div>
 
-      {/* Error message — prominent display */}
-      {session.error_message && (
+      {/* Error message — only shown for errored sessions, not intentional stops */}
+      {session.status === 'error' && session.error_message && (
         <div className="mt-2 rounded-md bg-destructive/10 px-3 py-2 text-xs text-destructive">
           <div className="flex items-start gap-2">
             <AlertCircle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
@@ -784,6 +788,12 @@ function SessionCard({ session, isActive, projectId, onConnect, onStop, onDismis
               Stop
             </Button>
           </>
+        )}
+        {session.status === 'stopping' && (
+          <Button variant="outline" size="sm" className="h-7 text-xs" disabled>
+            <Loader2 className="mr-1 h-3 w-3 animate-spin" />
+            Stopping...
+          </Button>
         )}
         {/* View Logs button — available for any session with a container */}
         <Button

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -278,7 +278,7 @@ export interface DocumentContent {
 // ── Emulation types ──
 
 export type EmulationMode = 'user' | 'system'
-export type EmulationStatus = 'created' | 'starting' | 'running' | 'stopped' | 'error'
+export type EmulationStatus = 'created' | 'starting' | 'running' | 'stopping' | 'stopped' | 'error'
 
 export interface PortForward {
   host: number


### PR DESCRIPTION
- Delete sessions — added trash button on stopped and error session cards to remove them from the DB. Sessions can only be deleted when not active. Includes DELETE /{session_id} backend endpoint and migration adding a logs column to emulation_sessions.
- Stopping state — clicking Stop now immediately flips the card to an orange "Stopping..." badge with a disabled spinner. The card updates to "Stopped" once the API responds.
- Log persistence — QEMU logs are captured from the container before it is removed on stop, so the Logs button still works after a session is stopped.
- Log panel auto-refresh — if the log panel is open while a session is stopping, it automatically re-fetches and displays the saved logs once the session reaches stopped status.
- No error on stopped sessions — "Container no longer exists" was showing as an error on intentionally stopped sessions. Error messages are now only shown for sessions in error status.
- Session list filtered by mode — the session list only shows sessions matching the currently selected mode (User/System).