### PR TITLE
fix network settings so that podman-compose can launch

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -114,3 +114,5 @@ volumes:
 networks:
   emulation_net:
     internal: true
+  default:
+    driver: bridge


### PR DESCRIPTION
I needed to add the default network to run it with `podman-compose up`. Otherwise I got an error and the startup failed immediately.