### PR TITLE
fix(mcp): support projects with multiple firmware versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,10 @@ Add to your `opencode.json` (project root or `~/.config/opencode/opencode.json`)
 
 Once connected, your AI agent can autonomously explore firmware, analyze binaries, run emulation, fuzz targets, and generate security findings. The MCP server supports dynamic project switching via the `switch_project` tool — no restart needed to change projects.
 
+#### Projects with multiple firmware versions
+
+When a project has more than one firmware uploaded (useful for diffing across versions via `diff_firmware`), the MCP server picks the earliest-uploaded unpacked firmware by default. To target a specific version, add `--firmware-id <FIRMWARE_ID>` to the launch command, or pass `firmware_id` to the `switch_project` MCP tool. Use `list_firmware_versions` to find IDs.
+
 ### MCP Tools (60+)
 
 | Category | Tools |

--- a/backend/app/mcp_server.py
+++ b/backend/app/mcp_server.py
@@ -1,11 +1,14 @@
 """Wairz MCP Server — exposes firmware analysis tools via the Model Context Protocol.
 
 Usage:
-    wairz-mcp --project-id <uuid>
+    wairz-mcp --project-id <uuid> [--firmware-id <uuid>]
 
 Connects to the Wairz database, loads the specified project and firmware,
 then serves all registered analysis tools over stdio for MCP-compatible
 clients (Claude Code, Claude Desktop, OpenCode, etc.).
+
+When a project has multiple firmware versions, --firmware-id selects a
+specific one. Without it, the earliest-uploaded unpacked firmware is used.
 
 Supports dynamic project switching via the switch_project tool — no need
 to restart the MCP server process when changing projects.
@@ -239,25 +242,71 @@ def _build_tool_registry() -> ToolRegistry:
     return registry
 
 
+def _select_firmware(
+    firmwares: list[Firmware],
+    firmware_id: uuid.UUID | None = None,
+) -> Firmware:
+    """Select a single firmware from a project's firmware list.
+
+    When *firmware_id* is provided, returns that specific firmware. Raises
+    ValueError if it doesn't exist in the list or hasn't been unpacked.
+
+    When *firmware_id* is None (the default), picks the earliest-created
+    firmware that has been unpacked. This is deterministic — the same project
+    always resolves to the same firmware — and matches the mental model of
+    "the first firmware I uploaded to this project."
+
+    Raises ValueError if the list is empty or no firmware has been unpacked.
+    """
+    if not firmwares:
+        raise ValueError("Project has no firmware uploaded.")
+
+    if firmware_id is not None:
+        for fw in firmwares:
+            if fw.id == firmware_id:
+                if not fw.extracted_path:
+                    raise ValueError(
+                        f"Firmware {firmware_id} has not been unpacked "
+                        f"(no extracted_path). Upload status must be 'unpacked'."
+                    )
+                return fw
+        available = ", ".join(str(fw.id) for fw in firmwares)
+        raise ValueError(
+            f"Firmware {firmware_id} not found in this project. "
+            f"Available firmware IDs: {available}"
+        )
+
+    unpacked = [fw for fw in firmwares if fw.extracted_path]
+    if not unpacked:
+        raise ValueError(
+            "No firmware in this project has been unpacked yet. "
+            "Trigger unpack via the web UI or POST /api/v1/projects/<id>/firmware/<id>/unpack "
+            "before starting the MCP server."
+        )
+
+    unpacked.sort(key=lambda fw: fw.created_at)
+    return unpacked[0]
+
+
 async def _load_project(
-    session: AsyncSession, project_id: uuid.UUID
-) -> tuple[Project, Firmware]:
-    """Load and validate the project and its firmware."""
+    session: AsyncSession,
+    project_id: uuid.UUID,
+    firmware_id: uuid.UUID | None = None,
+) -> tuple[Project, Firmware, int]:
+    """Load and validate the project and its active firmware.
+
+    Returns a tuple of (project, selected_firmware, total_firmware_count).
+    The count lets callers log an informative message when the project has
+    multiple firmwares so users know they can select a different one.
+    """
     project = await session.get(Project, project_id)
     if not project:
         raise ValueError(f"Project {project_id} not found.")
 
     stmt = select(Firmware).where(Firmware.project_id == project_id)
-    firmware = (await session.execute(stmt)).scalar_one_or_none()
-    if not firmware:
-        raise ValueError(f"No firmware found for project {project_id}.")
-
-    if not firmware.extracted_path:
-        raise ValueError(
-            f"Firmware for project {project_id} has not been unpacked (no extracted_path)."
-        )
-
-    return project, firmware
+    firmwares = list((await session.execute(stmt)).scalars().all())
+    firmware = _select_firmware(firmwares, firmware_id)
+    return project, firmware, len(firmwares)
 
 
 async def _load_project_state(
@@ -265,10 +314,17 @@ async def _load_project_state(
     project_id: uuid.UUID,
     state: ProjectState,
     host_storage_root: str | None,
-) -> None:
-    """Load project data from DB into the mutable state object."""
+    firmware_id: uuid.UUID | None = None,
+) -> int:
+    """Load project data from DB into the mutable state object.
+
+    Returns the total number of firmwares in the project, so callers can
+    emit an informative log when more than one is available.
+    """
     async with session_factory() as session:
-        project, firmware = await _load_project(session, project_id)
+        project, firmware, firmware_count = await _load_project(
+            session, project_id, firmware_id
+        )
         state.project_id = project.id
         state.project_name = project.name
         state.project_desc = project.description or ""
@@ -285,8 +341,13 @@ async def _load_project_state(
         if state.extraction_dir:
             state.extraction_dir = _translate_path(state.extraction_dir, host_storage_root)
 
+    return firmware_count
 
-async def run_server(project_id: uuid.UUID) -> None:
+
+async def run_server(
+    project_id: uuid.UUID,
+    firmware_id: uuid.UUID | None = None,
+) -> None:
     """Start the MCP server for a given project."""
     settings = get_settings()
 
@@ -311,10 +372,22 @@ async def run_server(project_id: uuid.UUID) -> None:
 
     # Load initial project
     try:
-        await _load_project_state(session_factory, project_id, state, host_storage_root)
+        firmware_count = await _load_project_state(
+            session_factory, project_id, state, host_storage_root, firmware_id
+        )
     except ValueError as exc:
         logger.error(str(exc))
         sys.exit(1)
+
+    if firmware_count > 1 and firmware_id is None:
+        logger.info(
+            "Project has %d firmware versions; selected '%s' (%s) as the active firmware. "
+            "Pass --firmware-id <uuid> to select a different one, or use the "
+            "list_firmware_versions MCP tool to see all versions.",
+            firmware_count,
+            state.firmware_filename,
+            state.firmware_id,
+        )
 
     if not os.path.isdir(state.extracted_path):
         logger.error(
@@ -383,7 +456,15 @@ async def run_server(project_id: uuid.UUID) -> None:
         except ValueError:
             return f"Error: '{new_project_id_str}' is not a valid UUID."
 
-        if new_project_id == state.project_id:
+        new_firmware_id: uuid.UUID | None = None
+        new_firmware_id_str = input.get("firmware_id")
+        if new_firmware_id_str:
+            try:
+                new_firmware_id = uuid.UUID(new_firmware_id_str)
+            except ValueError:
+                return f"Error: '{new_firmware_id_str}' is not a valid UUID."
+
+        if new_project_id == state.project_id and new_firmware_id is None:
             return (
                 f"Already connected to project '{state.project_name}' "
                 f"({state.project_id})."
@@ -391,19 +472,28 @@ async def run_server(project_id: uuid.UUID) -> None:
 
         old_name = state.project_name
         old_id = state.project_id
+        old_firmware_id = state.firmware_id
 
         try:
             await _load_project_state(
-                session_factory, new_project_id, state, host_storage_root
+                session_factory,
+                new_project_id,
+                state,
+                host_storage_root,
+                new_firmware_id,
             )
         except ValueError as exc:
             return f"Error: {exc}"
 
         if not os.path.isdir(state.extracted_path):
-            # Revert to old project
+            # Revert to old project + firmware
             try:
                 await _load_project_state(
-                    session_factory, old_id, state, host_storage_root
+                    session_factory,
+                    old_id,
+                    state,
+                    host_storage_root,
+                    old_firmware_id,
                 )
             except ValueError:
                 pass
@@ -434,8 +524,9 @@ async def run_server(project_id: uuid.UUID) -> None:
         description=(
             "Switch the MCP server to a different Wairz project without restarting. "
             "Takes a project UUID and reloads all context (firmware, paths, metadata). "
-            "Use this when you need to analyze a different project. "
-            "Call get_project_info afterwards to confirm the switch."
+            "When the target project has multiple firmware versions, pass firmware_id "
+            "to pick a specific one; otherwise the earliest-uploaded unpacked firmware "
+            "is selected. Call get_project_info afterwards to confirm the switch."
         ),
         input_schema={
             "type": "object",
@@ -443,6 +534,14 @@ async def run_server(project_id: uuid.UUID) -> None:
                 "project_id": {
                     "type": "string",
                     "description": "UUID of the project to switch to.",
+                },
+                "firmware_id": {
+                    "type": "string",
+                    "description": (
+                        "Optional UUID of a specific firmware version within the target "
+                        "project. If omitted, the earliest-uploaded unpacked firmware "
+                        "is used. Use list_firmware_versions to see available IDs."
+                    ),
                 },
             },
             "required": ["project_id"],
@@ -610,6 +709,17 @@ def main() -> None:
         type=str,
         help="UUID of the project to analyze.",
     )
+    parser.add_argument(
+        "--firmware-id",
+        type=str,
+        default=None,
+        help=(
+            "UUID of a specific firmware version within the project. "
+            "Optional — when omitted, the earliest-uploaded unpacked firmware "
+            "is selected. Use list_firmware_versions (MCP tool) or the project "
+            "detail page in the web UI to find firmware IDs."
+        ),
+    )
     args = parser.parse_args()
 
     try:
@@ -618,7 +728,17 @@ def main() -> None:
         print(f"Error: '{args.project_id}' is not a valid UUID.", file=sys.stderr)
         sys.exit(1)
 
-    asyncio.run(run_server(project_id))
+    firmware_id: uuid.UUID | None = None
+    if args.firmware_id is not None:
+        try:
+            firmware_id = uuid.UUID(args.firmware_id)
+        except ValueError:
+            print(
+                f"Error: '{args.firmware_id}' is not a valid UUID.", file=sys.stderr
+            )
+            sys.exit(1)
+
+    asyncio.run(run_server(project_id, firmware_id))
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_mcp_firmware_selection.py
+++ b/backend/tests/test_mcp_firmware_selection.py
@@ -1,0 +1,85 @@
+"""Tests for MCP server firmware selection logic.
+
+Covers the `_select_firmware` helper, which is responsible for picking the
+active firmware from a project's firmware list. The helper is pulled out of
+the DB-bound `_load_project` wrapper so it can be tested without a database.
+"""
+
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+
+import pytest
+
+from app.mcp_server import _select_firmware
+
+
+@dataclass
+class _FakeFirmware:
+    """Minimal stand-in for the SQLAlchemy Firmware model.
+
+    `_select_firmware` only reads .id, .extracted_path, and .created_at, so a
+    dataclass avoids pulling in the async ORM stack just for these tests.
+    """
+    id: uuid.UUID
+    extracted_path: str | None
+    created_at: datetime
+
+
+def _fw(idx: int, *, extracted: bool = True, offset_seconds: int = 0) -> _FakeFirmware:
+    """Build a fake firmware with a deterministic UUID and created_at ordering."""
+    return _FakeFirmware(
+        id=uuid.UUID(int=idx),
+        extracted_path=f"/data/fw{idx}" if extracted else None,
+        created_at=datetime(2026, 1, 1) + timedelta(seconds=offset_seconds),
+    )
+
+
+class TestSelectFirmware:
+    def test_empty_list_raises(self):
+        with pytest.raises(ValueError, match="no firmware uploaded"):
+            _select_firmware([])
+
+    def test_single_firmware_returned(self):
+        fw = _fw(1)
+        assert _select_firmware([fw]) is fw
+
+    def test_multiple_picks_earliest_unpacked(self):
+        """With multiple unpacked firmwares, the earliest-created one wins."""
+        fw_old = _fw(1, offset_seconds=0)
+        fw_mid = _fw(2, offset_seconds=100)
+        fw_new = _fw(3, offset_seconds=200)
+        # Pass in reverse order to prove we're not relying on input order.
+        assert _select_firmware([fw_new, fw_mid, fw_old]) is fw_old
+
+    def test_unpacked_required_when_no_id_specified(self):
+        """Non-unpacked firmwares are skipped even if they were uploaded first."""
+        fw_pending = _fw(1, extracted=False, offset_seconds=0)
+        fw_ready = _fw(2, extracted=True, offset_seconds=100)
+        assert _select_firmware([fw_pending, fw_ready]) is fw_ready
+
+    def test_no_unpacked_raises(self):
+        firmwares = [_fw(i, extracted=False, offset_seconds=i) for i in range(1, 4)]
+        with pytest.raises(ValueError, match="has been unpacked"):
+            _select_firmware(firmwares)
+
+    def test_explicit_id_returns_that_firmware(self):
+        firmwares = [_fw(i, offset_seconds=i) for i in range(1, 4)]
+        target = firmwares[1]  # not the earliest
+        assert _select_firmware(firmwares, firmware_id=target.id) is target
+
+    def test_explicit_id_not_found_raises(self):
+        firmwares = [_fw(i) for i in range(1, 4)]
+        missing = uuid.UUID(int=999)
+        with pytest.raises(ValueError, match="not found in this project"):
+            _select_firmware(firmwares, firmware_id=missing)
+
+    def test_explicit_id_must_be_unpacked(self):
+        """When targeting a specific firmware, require it to be unpacked.
+
+        Without this check, the MCP server would start against a firmware that
+        has no extracted_path and fail confusingly on the first tool call.
+        """
+        fw = _fw(1, extracted=False)
+        with pytest.raises(ValueError, match="has not been unpacked"):
+            _select_firmware([fw], firmware_id=fw.id)


### PR DESCRIPTION
## Problem

The MCP server crashes at startup when its target project contains more than one firmware. The bootstrap path in `_load_project` uses `scalar_one_or_none()` to fetch the firmware row, which raises `sqlalchemy.exc.MultipleResultsFound` as soon as there are 2+ rows.

This contradicts several MCP tools already in the registry that assume multi-firmware projects — `list_firmware_versions`, `diff_firmware`, `diff_binary`, `diff_decompilation`. Today a client cannot actually use cross-version diffing from MCP, because the server crashes before it gets a chance to expose those tools.

### Reproduction

```bash
# Create a project and upload two firmwares
PROJECT_ID=$(curl -s -X POST http://localhost:8000/api/v1/projects \
  -H 'Content-Type: application/json' \
  -d '{"name":"multi-fw"}' | jq -r .id)

curl -X POST "http://localhost:8000/api/v1/projects/$PROJECT_ID/firmware" \
  -F file=@firmware_v1.bin
curl -X POST "http://localhost:8000/api/v1/projects/$PROJECT_ID/firmware" \
  -F file=@firmware_v2.bin
# (unpack both)

# Launch MCP
docker exec -i wairz-backend-1 uv run wairz-mcp --project-id "$PROJECT_ID"
```

Before this PR:
```
sqlalchemy.exc.MultipleResultsFound: Multiple rows were found when one or none was required
```

After this PR:
```
[INFO] wairz.mcp: Project has 2 firmware versions; selected 'firmware_v1.bin' (<uuid>) as the active firmware. Pass --firmware-id <uuid> to select a different one, or use the list_firmware_versions MCP tool to see all versions.
[INFO] wairz.mcp: Loaded project 'multi-fw' — firmware: firmware_v1.bin (...)
```

## Changes

- **Extracted firmware selection into a pure `_select_firmware()` helper** so the selection logic is testable without a database. Default picks the earliest-uploaded unpacked firmware — deterministic, reproducible across sessions.
- **New `--firmware-id <uuid>` CLI flag** on `wairz-mcp` to target a specific firmware version. Validated at startup with actionable errors:
  - Unknown ID → lists available firmware IDs.
  - ID exists but not unpacked → tells the user to trigger unpack first.
- **`switch_project` MCP tool now accepts optional `firmware_id`** so clients can swap firmwares without restarting. Backward compatible — existing single-arg calls behave identically.
- **Informative INFO log** whenever the project has more than one firmware and none was explicitly selected, so users are never surprised by which version is active.
- **8 new unit tests** covering the selection helper (empty list, single firmware, multi-firmware with defaults, explicit ID targeting, missing ID handling, unpacked-only filtering). Uses a dataclass stand-in for the ORM model so no DB fixture is required.
- **README note** in the MCP section covering the multi-firmware workflow.

## Backward compatibility

Single-firmware projects and existing launch commands continue to work unchanged — `--firmware-id` is optional. The change is purely additive for existing users.

## Test plan

- [x] `uv run pytest tests/test_mcp_firmware_selection.py` — 8 passed
- [x] Full test suite — same 4 pre-existing failures (unrelated test rot in `test_binary_tools.py` / `test_tool_registry.py`); no new failures from this change
- [x] End-to-end with two firmwares uploaded:
  - Default launch picks earliest + logs multi-firmware notice
  - Explicit `--firmware-id` for an unpacked firmware loads it
  - Explicit `--firmware-id` for an unpacked-less firmware errors with guidance
  - Bogus `--firmware-id` errors listing available IDs