### PR TITLE
feat(unpack): detect and unwrap 7-Zip firmware containers on upload

### DIFF
--- a/backend/app/routers/firmware.py
+++ b/backend/app/routers/firmware.py
@@ -36,7 +36,12 @@ async def upload_firmware(
     version_label: str | None = Form(None),
     service: FirmwareService = Depends(get_firmware_service),
 ):
-    firmware = await service.upload(project_id, file, version_label=version_label)
+    try:
+        firmware = await service.upload(project_id, file, version_label=version_label)
+    except ValueError as e:
+        # Service raises ValueError for rejectable uploads — e.g. a
+        # password-protected 7z that can't be unwrapped automatically.
+        raise HTTPException(400, str(e))
     return firmware
 
 

--- a/backend/app/services/firmware_service.py
+++ b/backend/app/services/firmware_service.py
@@ -1,8 +1,10 @@
+import asyncio
 import hashlib
 import os
 import re
 import shutil
 import tarfile
+import tempfile
 import uuid
 import zipfile
 
@@ -13,6 +15,16 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import get_settings
 from app.models.firmware import Firmware
+
+
+_7Z_MAGIC = b"\x37\x7a\xbc\xaf\x27\x1c"
+# 7z's CLI writes password-prompt errors to stderr; match on stable fragments
+# rather than the full message (wording varies slightly across p7zip versions).
+_7Z_ENCRYPTED_MARKERS = (
+    "Cannot open encrypted archive",
+    "Wrong password",
+    "Can not open encrypted archive",
+)
 
 
 def _sanitize_filename(name: str) -> str:
@@ -63,6 +75,92 @@ def _extract_firmware_from_zip(zip_path: str, output_dir: str) -> str | None:
                 dst.write(chunk)
 
         return target_path
+
+
+def _is_7z_archive(path: str) -> bool:
+    """Return True if the file begins with the 7-Zip magic signature.
+
+    Uses magic-bytes detection rather than extension matching because
+    vendor OTAs sometimes ship 7z-wrapped firmware with misleading
+    extensions (e.g. ``.img``). The 6-byte signature is specific enough
+    that false positives are effectively impossible.
+    """
+    try:
+        with open(path, "rb") as f:
+            return f.read(len(_7Z_MAGIC)) == _7Z_MAGIC
+    except OSError:
+        return False
+
+
+async def _extract_firmware_from_7z(archive_path: str, output_dir: str) -> str | None:
+    """Extract the largest file from an unencrypted 7-Zip archive.
+
+    Runs the 7z tool with an empty password so unencrypted archives unwrap
+    without ever blocking on a prompt. Extraction goes into a temp
+    sub-directory so any path-traversal attempts in the archive are
+    contained; only the chosen inner file is moved into output_dir.
+
+    Returns the path to the extracted firmware, or None if the archive
+    contained no usable file.
+
+    Raises:
+        ValueError: The archive is password-protected. Message starts with
+            "Archive is password-protected" so callers can identify it and
+            convert to HTTP 400.
+        RuntimeError: Extraction failed for another reason (corrupt
+            archive, out of disk, etc). Callers may choose to fall back to
+            treating the upload as a raw binary.
+    """
+    extract_dir = tempfile.mkdtemp(prefix="7z_extract_", dir=output_dir)
+    try:
+        argv = ["7z", "x", f"-o{extract_dir}", "-y", "-p", archive_path]
+        proc = await asyncio.create_subprocess_exec(
+            *argv,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await proc.communicate()
+        combined = (stdout + stderr).decode("utf-8", errors="replace")
+
+        if proc.returncode != 0:
+            if any(marker in combined for marker in _7Z_ENCRYPTED_MARKERS):
+                raise ValueError(
+                    "Archive is password-protected. Decrypt the archive "
+                    "locally and re-upload the inner firmware image."
+                )
+            raise RuntimeError(
+                f"7z extraction failed (exit {proc.returncode}): "
+                f"{combined.strip() or 'no output'}"
+            )
+
+        largest_path: str | None = None
+        largest_size = -1
+        for root, _dirs, files in os.walk(extract_dir):
+            for name in files:
+                if name.startswith(".") or name.startswith("__"):
+                    continue
+                path = os.path.join(root, name)
+                try:
+                    size = os.path.getsize(path)
+                except OSError:
+                    continue
+                if size > largest_size:
+                    largest_size = size
+                    largest_path = path
+
+        if largest_path is None:
+            return None
+
+        target_name = _sanitize_filename(os.path.basename(largest_path))
+        target_path = os.path.join(output_dir, target_name)
+        # Avoid colliding with the original archive still in output_dir.
+        if os.path.exists(target_path):
+            base, ext = os.path.splitext(target_name)
+            target_path = os.path.join(output_dir, f"{base}_extracted{ext}")
+        shutil.move(largest_path, target_path)
+        return target_path
+    finally:
+        shutil.rmtree(extract_dir, ignore_errors=True)
 
 
 def _extract_archive(archive_path: str, output_dir: str) -> None:
@@ -134,6 +232,31 @@ class FirmwareService:
                 os.remove(storage_path)
                 storage_path = extracted
                 # Recompute hash and size for the actual firmware content
+                sha256_hash = hashlib.sha256()
+                file_size = 0
+                async with aiofiles.open(storage_path, "rb") as f:
+                    while chunk := await f.read(8192):
+                        sha256_hash.update(chunk)
+                        file_size += len(chunk)
+
+        # 7z wrapper — detected by magic bytes because vendor OTAs often ship
+        # 7z-wrapped firmware with misleading extensions (e.g. Creality K1 Max
+        # ships a 7z OTA as .img). binwalk does not descend into 7z containers,
+        # so without this the firmware would appear unrecognizable to the
+        # unpack pipeline.
+        elif _is_7z_archive(storage_path):
+            try:
+                extracted = await _extract_firmware_from_7z(storage_path, firmware_dir)
+            except RuntimeError:
+                # Corrupt or otherwise non-extractable — fall through and let
+                # binwalk surface whatever it can. We're no worse off than today.
+                extracted = None
+            # Note: ValueError (password-protected) intentionally propagates;
+            # the router converts it to HTTP 400 so the user gets actionable
+            # feedback instead of an unpack failure later.
+            if extracted:
+                os.remove(storage_path)
+                storage_path = extracted
                 sha256_hash = hashlib.sha256()
                 file_size = 0
                 async with aiofiles.open(storage_path, "rb") as f:

--- a/backend/tests/test_firmware_7z_unwrap.py
+++ b/backend/tests/test_firmware_7z_unwrap.py
@@ -1,0 +1,145 @@
+"""Tests for 7-Zip wrapper detection and unwrap in firmware uploads.
+
+Covers the helpers that run before binwalk, so the unpack pipeline sees a
+raw firmware image instead of the 7z container that some vendor OTAs ship.
+
+These tests shell out to the real `7z` binary (already installed in the
+backend container via p7zip-full). Skipped when 7z is unavailable on the
+test runner.
+"""
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from app.services.firmware_service import (
+    _7Z_MAGIC,
+    _extract_firmware_from_7z,
+    _is_7z_archive,
+)
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("7z") is None,
+    reason="7z binary not available on this system",
+)
+
+
+# ---------------------------------------------------------------------------
+# Magic-byte detection
+# ---------------------------------------------------------------------------
+
+class TestIs7zArchive:
+    def test_valid_magic(self, tmp_path: Path):
+        path = tmp_path / "fw.bin"
+        # Real 7z file needs more than just magic; we only probe the first
+        # 6 bytes, so padding with zeros is enough for this check.
+        path.write_bytes(_7Z_MAGIC + b"\x00" * 100)
+        assert _is_7z_archive(str(path)) is True
+
+    def test_wrong_magic(self, tmp_path: Path):
+        path = tmp_path / "fw.bin"
+        path.write_bytes(b"MZ\x00\x00\x00\x00" + b"\x00" * 100)
+        assert _is_7z_archive(str(path)) is False
+
+    def test_too_short(self, tmp_path: Path):
+        """Files shorter than 6 bytes cannot match the magic signature."""
+        path = tmp_path / "fw.bin"
+        path.write_bytes(b"\x37\x7a")
+        assert _is_7z_archive(str(path)) is False
+
+    def test_missing_file(self, tmp_path: Path):
+        assert _is_7z_archive(str(tmp_path / "does-not-exist.bin")) is False
+
+
+# ---------------------------------------------------------------------------
+# Extraction
+# ---------------------------------------------------------------------------
+
+def _make_unencrypted_7z(workdir: Path) -> tuple[Path, Path]:
+    """Build an unencrypted 7z containing a small inner 'firmware.bin'.
+
+    Returns (archive_path, inner_content_bytes_length).
+    """
+    inner = workdir / "firmware.bin"
+    # A recognizable payload so we can sanity-check extraction round-tripped.
+    payload = b"FIRMWARE_MARKER_" + b"x" * 2048
+    inner.write_bytes(payload)
+
+    archive = workdir / "wrapped.7z"
+    result = subprocess.run(
+        ["7z", "a", "-bso0", "-bsp0", str(archive), str(inner)],
+        check=True,
+        capture_output=True,
+    )
+    assert result.returncode == 0
+    inner.unlink()  # leave only the archive
+    return archive, payload
+
+
+def _make_encrypted_7z(workdir: Path, password: str) -> Path:
+    """Build a password-protected 7z (header-encrypted with -mhe=on)."""
+    inner = workdir / "secret.bin"
+    inner.write_bytes(b"ENCRYPTED_PAYLOAD" + b"x" * 1024)
+
+    archive = workdir / "encrypted.7z"
+    result = subprocess.run(
+        [
+            "7z", "a",
+            "-bso0", "-bsp0",
+            f"-p{password}",
+            "-mhe=on",  # header encryption — mirrors the Creality OTA setup
+            str(archive), str(inner),
+        ],
+        check=True,
+        capture_output=True,
+    )
+    assert result.returncode == 0
+    inner.unlink()
+    return archive
+
+
+async def test_extract_unencrypted_picks_largest(tmp_path: Path):
+    archive, payload = _make_unencrypted_7z(tmp_path)
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+    # The archive has to live inside output_dir's siblings, not output_dir
+    # itself, to match how firmware_service lays things out.
+    result = await _extract_firmware_from_7z(str(archive), str(output_dir))
+    assert result is not None
+    assert os.path.isfile(result)
+    assert Path(result).read_bytes() == payload
+
+
+async def test_extract_encrypted_raises_value_error(tmp_path: Path):
+    archive = _make_encrypted_7z(tmp_path, password="correcthorse")
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+    with pytest.raises(ValueError, match="password-protected"):
+        await _extract_firmware_from_7z(str(archive), str(output_dir))
+
+
+async def test_extract_corrupt_raises_runtime_error(tmp_path: Path):
+    # A file with correct magic but no real 7z structure after it.
+    archive = tmp_path / "corrupt.7z"
+    archive.write_bytes(_7Z_MAGIC + b"\x00" * 200)
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+    with pytest.raises(RuntimeError, match="7z extraction failed"):
+        await _extract_firmware_from_7z(str(archive), str(output_dir))
+
+
+async def test_extract_cleans_up_temp_dir_on_failure(tmp_path: Path):
+    """Extraction failures must not leave temp directories behind."""
+    archive = _make_encrypted_7z(tmp_path, password="secret")
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+
+    with pytest.raises(ValueError):
+        await _extract_firmware_from_7z(str(archive), str(output_dir))
+
+    # No 7z_extract_* directory should remain in output_dir
+    remaining = [p for p in output_dir.iterdir() if p.name.startswith("7z_extract_")]
+    assert remaining == []


### PR DESCRIPTION
## Problem

Vendor OTAs occasionally ship firmware inside a 7-Zip container. The Creality K1 Max, for instance, publishes its OTA as a `.img` file that's actually a 7z archive. binwalk's extractor does not descend into 7z containers — even unencrypted ones — so uploads of 7z-wrapped firmware currently fail silently:

```
WARNING: One or more files failed to extract: either no utility was found or it's unimplemented
```

The user ends up with an "unpacked" firmware row whose filesystem has zero entries, no detected architecture, no kernel, and no explanation of what went wrong. Password-protected 7z files fail the same way, indistinguishable from a corrupt upload.

## Reproduction

Using any 7z-wrapped firmware (an unencrypted demo archive will do):

```bash
echo "hello firmware" > fw.bin
7z a wrapped.7z fw.bin
curl -X POST http://localhost:8000/api/v1/projects/<pid>/firmware \
  -F file=@wrapped.7z
curl -X POST http://localhost:8000/api/v1/projects/<pid>/firmware/<fid>/unpack
# Poll — unpack_log ends with "WARNING: One or more files failed to extract"
# architecture, kernel_path, extracted_path all remain null.
```

For a password-protected archive, the failure mode is identical — no indication that a password is even required.

## Solution

Mirror the existing `.zip` unwrap step that already lives in `firmware_service.upload`. Differences vs the zip path:

* **Detection by magic bytes, not extension.** 7z-wrapped firmware commonly ships with misleading extensions (e.g. Creality's `.img`). The 6-byte 7z signature (`37 7a bc af 27 1c`) at offset 0 is specific enough that false positives are not a concern.
* **Graceful encryption handling.** An empty password is tried; if the archive is password-protected the upload is rejected with `HTTP 400` and a message telling the user to decrypt locally. They find out at upload time, not after a confusing unpack cycle.
* **Corrupt archives fall through.** We don't want to regress any current behaviour — if 7z fails for a non-encryption reason, the file is left alone and binwalk runs as before.
* **Extraction is sandboxed.** A temp sub-directory holds the extraction so any path-traversal attempts in the archive are contained. Only the chosen inner file (largest, matching the zip heuristic) is moved into the firmware dir.

## Changes

- `backend/app/services/firmware_service.py` — new `_is_7z_archive` and async `_extract_firmware_from_7z` helpers; branch added to the upload flow.
- `backend/app/routers/firmware.py` — `upload_firmware` now catches `ValueError` from the service and converts it to `HTTP 400` (matching the pattern already used by `upload_rootfs`).
- `backend/tests/test_firmware_7z_unwrap.py` — 8 tests covering magic detection (valid, wrong, too short, missing file), unencrypted extraction, header-encrypted rejection, corrupt-archive handling, and temp-dir cleanup on failure. Tests shell out to the real `7z` binary (already installed via `p7zip-full` in `backend/Dockerfile`) and skip cleanly when it's unavailable.

## Out of scope

- Prompting for a password on encrypted archives. The maintainers can decide whether to add a `password` form field in a follow-up; this PR keeps the scope small and surfaces the problem without changing the upload contract.

## Test plan

- [x] `uv run pytest tests/test_firmware_7z_unwrap.py` — 8 passed
- [x] Full test suite — same 4 pre-existing failures (unrelated test rot in `test_binary_tools.py` / `test_tool_registry.py`); no new failures from this change
- [x] End-to-end: uploaded a real encrypted 7z OTA (Creality K1 Max S11) against a freshly rebuilt backend — returns `HTTP 400` with `{"detail":"Archive is password-protected. Decrypt the archive locally and re-upload the inner firmware image."}`