### PR TITLE
Add recursive filesystem extractor dispatcher

### DIFF
--- a/backend/app/workers/fs_extractors.py
+++ b/backend/app/workers/fs_extractors.py
@@ -1,0 +1,405 @@
+"""Recursive filesystem-image extractor — runs after binwalk.
+
+Binwalk with -Me handles the common case. This dispatcher catches:
+  * vendor-modified SquashFS that binwalk's signature scanner misses
+    (Zyxel, D-Link — falls back to sasquatch)
+  * UBI/UBIFS/JFFS2 images that binwalk produced but didn't further unpack
+  * Nested filesystems revealed only after each extraction pass
+
+All failures are logged, never raised. Binwalk remains the authoritative
+first-pass extractor; this module is a best-effort enrichment.
+"""
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import os
+import shutil
+import stat
+from typing import Awaitable, Callable, Literal
+
+from .unpack import _KERNEL_NAME_PATTERNS
+
+FsType = Literal["squashfs", "ubi", "ubifs", "jffs2", "cramfs", "ext", "cpio"]
+
+
+# Magic bytes at offset 0. Ext is the exception — see _detect_fs_type.
+_MAGICS: dict[FsType, tuple[bytes, ...]] = {
+    # hsqs LE, sqsh BE, plus older/less-common endian variants
+    "squashfs": (b"hsqs", b"sqsh", b"qshs", b"shsq"),
+    "ubi":      (b"UBI#",),
+    "ubifs":    (b"\x31\x18\x10\x06",),
+    "jffs2":    (b"\x85\x19", b"\x19\x85"),
+    "cramfs":   (b"\x45\x3d\xcd\x28", b"\x28\xcd\x3d\x45"),
+    "cpio":     (b"070701", b"070702", b"070707"),
+}
+
+# ext2/3/4 superblock starts at byte 0x400; s_magic (2 bytes) sits at
+# offset 0x38 within the superblock → absolute offset 0x438.
+_EXT_MAGIC_OFFSET = 0x438
+_EXT_MAGIC = b"\x53\xef"
+
+_MIN_FS_SIZE = 4 * 1024
+_MAX_FS_SIZE = 2 * 1024 * 1024 * 1024
+
+_SHA_CHUNK = 1024 * 1024  # 1 MB
+
+
+def _detect_fs_type(path: str) -> FsType | None:
+    try:
+        size = os.path.getsize(path)
+    except OSError:
+        return None
+    if size < _MIN_FS_SIZE or size > _MAX_FS_SIZE:
+        return None
+
+    try:
+        with open(path, "rb") as f:
+            head = f.read(8)
+            for fs_type, magics in _MAGICS.items():
+                for magic in magics:
+                    if head.startswith(magic):
+                        return fs_type
+
+            if size >= _EXT_MAGIC_OFFSET + len(_EXT_MAGIC):
+                f.seek(_EXT_MAGIC_OFFSET)
+                if f.read(len(_EXT_MAGIC)) == _EXT_MAGIC:
+                    return "ext"
+    except OSError:
+        return None
+
+    return None
+
+
+def _sha256_file(path: str) -> str | None:
+    h = hashlib.sha256()
+    try:
+        with open(path, "rb") as f:
+            while True:
+                chunk = f.read(_SHA_CHUNK)
+                if not chunk:
+                    break
+                h.update(chunk)
+    except OSError:
+        return None
+    return h.hexdigest()
+
+
+def _is_excluded(path: str, extraction_root_real: str) -> bool:
+    """Skip kernels, large ELF executables, and symlinks escaping the sandbox."""
+    name_lower = os.path.basename(path).lower()
+    if any(p in name_lower for p in _KERNEL_NAME_PATTERNS):
+        return True
+
+    try:
+        real = os.path.realpath(path)
+    except OSError:
+        return True
+    if not (real == extraction_root_real or real.startswith(extraction_root_real + os.sep)):
+        return True
+
+    try:
+        with open(path, "rb") as f:
+            if f.read(4) == b"\x7fELF":
+                if os.path.getsize(path) > 500_000:
+                    return True
+    except OSError:
+        return True
+
+    return False
+
+
+async def _run(
+    args: list[str],
+    timeout: int,
+    cwd: str | None = None,
+    stdin_path: str | None = None,
+) -> tuple[int | None, str]:
+    """Spawn a subprocess without a shell; return (returncode, combined output).
+
+    returncode is None on timeout or spawn failure.
+    """
+    stdin_file = None
+    try:
+        if stdin_path is not None:
+            stdin_file = open(stdin_path, "rb")
+        proc = await asyncio.create_subprocess_exec(
+            *args,
+            stdin=stdin_file if stdin_file else asyncio.subprocess.DEVNULL,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+            cwd=cwd,
+        )
+    except FileNotFoundError:
+        if stdin_file:
+            stdin_file.close()
+        return None, f"[tool not found: {args[0]}]"
+    except Exception as exc:
+        if stdin_file:
+            stdin_file.close()
+        return None, f"[spawn failed: {exc}]"
+
+    try:
+        stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+    except asyncio.TimeoutError:
+        proc.kill()
+        try:
+            await proc.wait()
+        except Exception:
+            pass
+        return None, f"[timeout after {timeout}s]"
+    finally:
+        if stdin_file:
+            stdin_file.close()
+
+    text = stdout.decode(errors="replace").replace("\x00", "")
+    return proc.returncode, text
+
+
+async def _extract_squashfs(src: str, out_dir: str, timeout: int) -> tuple[bool, str]:
+    # unsquashfs refuses to extract into an existing directory unless -f.
+    if os.path.exists(out_dir):
+        return False, "output dir already exists"
+
+    rc, _log = await _run(["unsquashfs", "-d", out_dir, src], timeout=timeout)
+    if rc == 0 and os.path.isdir(out_dir) and os.listdir(out_dir):
+        return True, "unsquashfs ok"
+
+    if os.path.isdir(out_dir):
+        shutil.rmtree(out_dir, ignore_errors=True)
+
+    if not shutil.which("sasquatch"):
+        return False, f"unsquashfs rc={rc}; sasquatch unavailable"
+
+    rc2, _log2 = await _run(["sasquatch", "-d", out_dir, src], timeout=timeout)
+    if rc2 == 0 and os.path.isdir(out_dir) and os.listdir(out_dir):
+        return True, "sasquatch ok (vendor-modified squashfs)"
+    return False, f"unsquashfs rc={rc}, sasquatch rc={rc2}"
+
+
+async def _extract_jffs2(src: str, out_dir: str, timeout: int) -> tuple[bool, str]:
+    os.makedirs(out_dir, exist_ok=True)
+    rc, _log = await _run(["jefferson", "-d", out_dir, src], timeout=timeout)
+    if rc == 0 and os.listdir(out_dir):
+        return True, "jefferson ok"
+    return False, f"jefferson rc={rc}"
+
+
+async def _extract_ubi(src: str, out_dir: str, timeout: int) -> tuple[bool, str]:
+    os.makedirs(out_dir, exist_ok=True)
+    rc, _log = await _run(
+        ["ubireader_extract_images", "-o", out_dir, src], timeout=timeout
+    )
+    if rc == 0 and os.listdir(out_dir):
+        return True, "ubireader_extract_images ok"
+    return False, f"ubireader_extract_images rc={rc}"
+
+
+async def _extract_ubifs(src: str, out_dir: str, timeout: int) -> tuple[bool, str]:
+    os.makedirs(out_dir, exist_ok=True)
+    rc, _log = await _run(
+        ["ubireader_extract_files", "-o", out_dir, src], timeout=timeout
+    )
+    if rc == 0 and os.listdir(out_dir):
+        return True, "ubireader_extract_files ok"
+    return False, f"ubireader_extract_files rc={rc}"
+
+
+async def _extract_cramfs(src: str, out_dir: str, timeout: int) -> tuple[bool, str]:
+    # The Dockerfile provides a cramfsck shim (lines 32-33) that accepts -x <dir>.
+    if os.path.exists(out_dir):
+        return False, "output dir already exists"
+    rc, _log = await _run(["cramfsck", "-x", out_dir, src], timeout=timeout)
+    if rc == 0 and os.path.isdir(out_dir) and os.listdir(out_dir):
+        return True, "cramfsck ok"
+    return False, f"cramfsck rc={rc}"
+
+
+async def _extract_ext(src: str, out_dir: str, timeout: int) -> tuple[bool, str]:
+    os.makedirs(out_dir, exist_ok=True)
+    rc, _log = await _run(
+        ["7z", "x", "-y", f"-o{out_dir}", src], timeout=timeout
+    )
+    if rc == 0 and os.listdir(out_dir):
+        return True, "7z ext ok"
+    return False, f"7z ext rc={rc}"
+
+
+async def _extract_cpio(src: str, out_dir: str, timeout: int) -> tuple[bool, str]:
+    os.makedirs(out_dir, exist_ok=True)
+    rc, _log = await _run(
+        ["cpio", "-idmv", "--no-absolute-filenames"],
+        timeout=timeout,
+        cwd=out_dir,
+        stdin_path=src,
+    )
+    if rc == 0 and os.listdir(out_dir):
+        return True, "cpio ok"
+    return False, f"cpio rc={rc}"
+
+
+_Extractor = Callable[[str, str, int], Awaitable[tuple[bool, str]]]
+_EXTRACTORS: dict[FsType, _Extractor] = {
+    "squashfs": _extract_squashfs,
+    "ubi":      _extract_ubi,
+    "ubifs":    _extract_ubifs,
+    "jffs2":    _extract_jffs2,
+    "cramfs":   _extract_cramfs,
+    "ext":      _extract_ext,
+    "cpio":     _extract_cpio,
+}
+
+
+def _extraction_output_dir(src: str) -> str:
+    base = f"{src}.extracted"
+    if not os.path.exists(base):
+        return base
+    i = 1
+    while os.path.exists(f"{base}.{i}"):
+        i += 1
+    return f"{base}.{i}"
+
+
+def _scan_candidates(
+    extraction_dir: str,
+    extraction_root_real: str,
+    seen_sha: set[str],
+) -> list[tuple[str, FsType, str]]:
+    """Return (path, fs_type, sha256) for unseen filesystem images."""
+    hits: list[tuple[str, FsType, str]] = []
+    for root, _dirs, files in os.walk(extraction_dir):
+        for name in files:
+            path = os.path.join(root, name)
+            try:
+                st = os.lstat(path)
+            except OSError:
+                continue
+            if not stat.S_ISREG(st.st_mode):
+                continue
+            if _is_excluded(path, extraction_root_real):
+                continue
+            fs_type = _detect_fs_type(path)
+            if fs_type is None:
+                continue
+            sha = _sha256_file(path)
+            if sha is None or sha in seen_sha:
+                continue
+            hits.append((path, fs_type, sha))
+    return hits
+
+
+def _count_yaffs_candidates(extraction_dir: str, extraction_root_real: str) -> int:
+    count = 0
+    for root, _dirs, files in os.walk(extraction_dir):
+        for name in files:
+            if name.lower().endswith((".yaffs", ".yaffs2")):
+                path = os.path.join(root, name)
+                if not _is_excluded(path, extraction_root_real):
+                    count += 1
+    return count
+
+
+def _dir_bytes(path: str) -> int:
+    total = 0
+    for root, _dirs, files in os.walk(path):
+        for name in files:
+            try:
+                total += os.path.getsize(os.path.join(root, name))
+            except OSError:
+                pass
+    return total
+
+
+async def recursive_extract(
+    extraction_dir: str,
+    *,
+    max_depth: int = 3,
+    per_extract_timeout: int = 300,
+    max_total_bytes_multiplier: float = 20.0,
+    original_size: int | None = None,
+) -> str:
+    """Extract filesystem images under ``extraction_dir`` until fixed-point.
+
+    Detects SquashFS/UBI/UBIFS/JFFS2/CramFS/ext2-4/cpio by magic bytes at
+    offset 0 (ext at 0x438). Dispatches to unsquashfs (with sasquatch
+    fallback), ubireader_extract_images/_files, jefferson, cramfsck, ``7z x``,
+    and ``cpio -idmv``. Each extraction writes to ``<file>.extracted/`` as a
+    sibling directory.
+
+    SHA256 deduplication prevents re-extracting identical blobs emitted
+    under multiple paths. Loops until no new images are found or max_depth
+    is reached. Per-extraction wall-clock timeout and a cumulative-size cap
+    (``original_size * multiplier``) guard against extraction bombs.
+
+    Log-and-continue on every failure; never raises. Returns a human-readable
+    multi-line log suitable for appending to ``firmware.unpack_log``.
+    """
+    lines: list[str] = [f"[fs_extractors] scanning {extraction_dir}"]
+    extraction_root_real = os.path.realpath(extraction_dir)
+    seen_sha: set[str] = set()
+    total_written = 0
+    size_cap: int | None = (
+        int(original_size * max_total_bytes_multiplier)
+        if original_size and max_total_bytes_multiplier > 0
+        else None
+    )
+    capped = False
+
+    for iteration in range(1, max_depth + 1):
+        if capped:
+            break
+        candidates = _scan_candidates(extraction_dir, extraction_root_real, seen_sha)
+        if not candidates:
+            lines.append(f"[fs_extractors] iter {iteration}: no new images; stopping")
+            break
+
+        lines.append(f"[fs_extractors] iter {iteration}: {len(candidates)} candidate(s)")
+        new_this_iter = 0
+
+        for src, fs_type, sha in candidates:
+            if sha in seen_sha:
+                continue
+            seen_sha.add(sha)
+
+            if size_cap is not None and total_written >= size_cap:
+                lines.append(
+                    f"[fs_extractors] size cap hit ({total_written} >= {size_cap}); "
+                    f"skipping remaining candidates"
+                )
+                capped = True
+                break
+
+            out_dir = _extraction_output_dir(src)
+            extractor = _EXTRACTORS.get(fs_type)
+            rel = os.path.relpath(src, extraction_dir)
+
+            if extractor is None:
+                lines.append(f"[fs_extractors] {fs_type} {rel}: no extractor registered")
+                continue
+
+            try:
+                ok, msg = await extractor(src, out_dir, per_extract_timeout)
+            except Exception as exc:
+                lines.append(f"[fs_extractors] {fs_type} {rel}: exception {exc!r}")
+                continue
+
+            lines.append(f"[fs_extractors] {fs_type} {rel}: {msg}")
+            if ok:
+                new_this_iter += 1
+                total_written += _dir_bytes(out_dir)
+
+        if new_this_iter == 0:
+            lines.append(f"[fs_extractors] iter {iteration}: nothing extracted; stopping")
+            break
+    else:
+        lines.append(f"[fs_extractors] reached max_depth={max_depth}; stopping")
+
+    yaffs_count = _count_yaffs_candidates(extraction_dir, extraction_root_real)
+    if yaffs_count:
+        lines.append(
+            f"[fs_extractors] {yaffs_count} YAFFS image(s) detected; "
+            f"manual extraction with yaffshiv (needs page+OOB size hints) required"
+        )
+
+    lines.append("[fs_extractors] done")
+    return "\n".join(lines) + "\n"

--- a/backend/app/workers/unpack.py
+++ b/backend/app/workers/unpack.py
@@ -33,10 +33,16 @@ _ELF_ARCH_MAP = {
 }
 
 
-async def run_binwalk_extraction(firmware_path: str, output_dir: str, timeout: int = 600) -> str:
-    """Run binwalk -e to extract firmware contents. Returns stdout+stderr."""
+async def run_binwalk_extraction(firmware_path: str, output_dir: str, timeout: int = 1800) -> str:
+    """Run binwalk with matryoshka recursion to extract firmware contents.
+
+    -M enables matryoshka mode so binwalk re-scans its own outputs; -d 5 caps
+    recursion depth to keep wall-clock bounded. The post-binwalk dispatcher
+    in ``fs_extractors.py`` picks up any filesystems binwalk's signature
+    scanner missed (e.g. vendor-modified SquashFS).
+    """
     proc = await asyncio.create_subprocess_exec(
-        "binwalk", "-e", "-C", output_dir, firmware_path,
+        "binwalk", "-Me", "-d", "5", "-C", output_dir, firmware_path,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.STDOUT,
     )
@@ -411,6 +417,8 @@ def detect_kernel(extraction_dir: str, fs_root: str | None) -> str | None:
 
 async def unpack_firmware(firmware_path: str, output_base_dir: str) -> UnpackResult:
     """Orchestrate the full unpacking pipeline."""
+    from .fs_extractors import recursive_extract
+
     result = UnpackResult()
 
     # Step 1: Run binwalk extraction
@@ -426,6 +434,19 @@ async def unpack_firmware(firmware_path: str, output_base_dir: str) -> UnpackRes
         result.error = f"Extraction failed: {e}"
         result.unpack_log = str(e)
         return result
+
+    # Step 1b: Custom recursive pass for filesystem images binwalk missed
+    # (e.g. vendor-modified SquashFS that needs sasquatch, or UBI/JFFS2
+    # blobs binwalk extracted but didn't further unpack). Log-and-continue
+    # on failures; never fails the overall unpack.
+    try:
+        original_size = os.path.getsize(firmware_path)
+    except OSError:
+        original_size = None
+    dispatcher_log = await recursive_extract(
+        extraction_dir, original_size=original_size
+    )
+    result.unpack_log = (result.unpack_log or "") + "\n" + dispatcher_log
 
     # Step 2: Find the filesystem root
     fs_root = find_filesystem_root(extraction_dir)

--- a/backend/tests/test_fs_extractors.py
+++ b/backend/tests/test_fs_extractors.py
@@ -1,0 +1,293 @@
+"""Unit tests for the recursive filesystem-image dispatcher."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from app.workers import fs_extractors
+from app.workers.fs_extractors import (
+    _MAGICS,
+    _detect_fs_type,
+    _is_excluded,
+    _sha256_file,
+    recursive_extract,
+)
+
+
+def _write(path: Path, data: bytes, pad_to: int | None = None) -> None:
+    """Write *data* to *path*, optionally zero-padding up to *pad_to* bytes."""
+    if pad_to is not None and len(data) < pad_to:
+        data = data + b"\x00" * (pad_to - len(data))
+    path.write_bytes(data)
+
+
+MIN_SIZE = 4 * 1024  # matches fs_extractors._MIN_FS_SIZE
+
+
+# ---------------------------------------------------------------------------
+# _detect_fs_type
+# ---------------------------------------------------------------------------
+
+class TestDetect:
+    def test_squashfs_hsqs(self, tmp_path: Path):
+        p = tmp_path / "img.bin"
+        _write(p, b"hsqs" + b"\x00" * 60, pad_to=MIN_SIZE)
+        assert _detect_fs_type(str(p)) == "squashfs"
+
+    def test_squashfs_sqsh_be(self, tmp_path: Path):
+        p = tmp_path / "img.bin"
+        _write(p, b"sqsh" + b"\x00" * 60, pad_to=MIN_SIZE)
+        assert _detect_fs_type(str(p)) == "squashfs"
+
+    def test_ubi(self, tmp_path: Path):
+        p = tmp_path / "img.bin"
+        _write(p, b"UBI#" + b"\x00" * 60, pad_to=MIN_SIZE)
+        assert _detect_fs_type(str(p)) == "ubi"
+
+    def test_ubifs(self, tmp_path: Path):
+        p = tmp_path / "img.bin"
+        _write(p, b"\x31\x18\x10\x06" + b"\x00" * 60, pad_to=MIN_SIZE)
+        assert _detect_fs_type(str(p)) == "ubifs"
+
+    def test_jffs2_le(self, tmp_path: Path):
+        p = tmp_path / "img.bin"
+        _write(p, b"\x85\x19" + b"\x00" * 60, pad_to=MIN_SIZE)
+        assert _detect_fs_type(str(p)) == "jffs2"
+
+    def test_jffs2_be(self, tmp_path: Path):
+        p = tmp_path / "img.bin"
+        _write(p, b"\x19\x85" + b"\x00" * 60, pad_to=MIN_SIZE)
+        assert _detect_fs_type(str(p)) == "jffs2"
+
+    def test_cramfs(self, tmp_path: Path):
+        p = tmp_path / "img.bin"
+        _write(p, b"\x45\x3d\xcd\x28" + b"\x00" * 60, pad_to=MIN_SIZE)
+        assert _detect_fs_type(str(p)) == "cramfs"
+
+    def test_cpio(self, tmp_path: Path):
+        p = tmp_path / "img.bin"
+        _write(p, b"070701" + b"\x00" * 60, pad_to=MIN_SIZE)
+        assert _detect_fs_type(str(p)) == "cpio"
+
+    def test_ext4_at_offset_0x438(self, tmp_path: Path):
+        # Junk in the first 1024 bytes (bootloader area), then the superblock.
+        # The ext magic sits at absolute offset 0x438.
+        buf = bytearray(b"\x00" * 0x600)
+        buf[0x438:0x43A] = b"\x53\xef"
+        p = tmp_path / "img.bin"
+        _write(p, bytes(buf), pad_to=MIN_SIZE)
+        assert _detect_fs_type(str(p)) == "ext"
+
+    def test_too_small(self, tmp_path: Path):
+        # SquashFS magic but under MIN_FS_SIZE — should be rejected.
+        p = tmp_path / "tiny.bin"
+        p.write_bytes(b"hsqs" + b"\x00" * 100)
+        assert _detect_fs_type(str(p)) is None
+
+    def test_no_match(self, tmp_path: Path):
+        p = tmp_path / "random.bin"
+        _write(p, b"random garbage" + b"\x00" * 60, pad_to=MIN_SIZE)
+        assert _detect_fs_type(str(p)) is None
+
+    def test_all_magics_have_tests(self):
+        # Sanity check: ensure every declared magic is exercised above by
+        # counting how many FsTypes we have tests for. If someone adds a
+        # new FsType to _MAGICS, they should add a test here.
+        expected = {"squashfs", "ubi", "ubifs", "jffs2", "cramfs", "cpio", "ext"}
+        declared = set(_MAGICS.keys()) | {"ext"}
+        assert declared == expected
+
+
+# ---------------------------------------------------------------------------
+# _is_excluded
+# ---------------------------------------------------------------------------
+
+class TestExclusion:
+    def test_kernel_name(self, tmp_path: Path):
+        p = tmp_path / "vmlinux-5.15"
+        _write(p, b"anything" + b"\x00" * 60, pad_to=MIN_SIZE)
+        assert _is_excluded(str(p), str(tmp_path)) is True
+
+    def test_uimage_name(self, tmp_path: Path):
+        p = tmp_path / "uImage"
+        _write(p, b"anything" + b"\x00" * 60, pad_to=MIN_SIZE)
+        assert _is_excluded(str(p), str(tmp_path)) is True
+
+    def test_large_elf_executable(self, tmp_path: Path):
+        # Mimic an uncompressed vmlinux: \x7fELF magic + >500 KB size.
+        p = tmp_path / "some_binary"
+        _write(p, b"\x7fELF" + b"\x00" * 60, pad_to=600_000)
+        assert _is_excluded(str(p), str(tmp_path)) is True
+
+    def test_small_elf_not_excluded(self, tmp_path: Path):
+        # Small ELFs are just shared libraries / utilities — don't exclude.
+        p = tmp_path / "libfoo.so"
+        _write(p, b"\x7fELF" + b"\x00" * 60, pad_to=MIN_SIZE)
+        assert _is_excluded(str(p), str(tmp_path)) is False
+
+    def test_symlink_escaping_sandbox(self, tmp_path: Path):
+        outside = tmp_path.parent / "outside.bin"
+        outside.write_bytes(b"hsqs" + b"\x00" * MIN_SIZE)
+        inside_link = tmp_path / "linked.bin"
+        inside_link.symlink_to(outside)
+        assert _is_excluded(str(inside_link), str(tmp_path)) is True
+
+    def test_regular_file_in_sandbox(self, tmp_path: Path):
+        p = tmp_path / "inside.bin"
+        _write(p, b"hsqs" + b"\x00" * 60, pad_to=MIN_SIZE)
+        assert _is_excluded(str(p), str(tmp_path)) is False
+
+
+# ---------------------------------------------------------------------------
+# _sha256_file
+# ---------------------------------------------------------------------------
+
+class TestSha:
+    def test_identical_contents_same_sha(self, tmp_path: Path):
+        a = tmp_path / "a.bin"
+        b = tmp_path / "b.bin"
+        content = b"hsqs" + b"\x11" * MIN_SIZE
+        a.write_bytes(content)
+        b.write_bytes(content)
+        assert _sha256_file(str(a)) == _sha256_file(str(b))
+
+    def test_different_contents_different_sha(self, tmp_path: Path):
+        a = tmp_path / "a.bin"
+        b = tmp_path / "b.bin"
+        a.write_bytes(b"hsqs" + b"\x11" * MIN_SIZE)
+        b.write_bytes(b"hsqs" + b"\x22" * MIN_SIZE)
+        assert _sha256_file(str(a)) != _sha256_file(str(b))
+
+
+# ---------------------------------------------------------------------------
+# recursive_extract orchestration
+# ---------------------------------------------------------------------------
+
+def _install_fake_extractor(monkeypatch, behaviour):
+    """Replace all real extractors with a single async fake.
+
+    *behaviour* is an async callable (src, out_dir, timeout) -> (ok, msg).
+    """
+    async def fake(src, out_dir, timeout):
+        return await behaviour(src, out_dir, timeout)
+
+    fake_map = {k: fake for k in fs_extractors._EXTRACTORS}
+    monkeypatch.setattr(fs_extractors, "_EXTRACTORS", fake_map)
+
+
+@pytest.mark.asyncio
+async def test_dedup_same_blob_under_two_names(tmp_path: Path, monkeypatch):
+    content = b"hsqs" + b"\xaa" * MIN_SIZE
+    (tmp_path / "a.squashfs").write_bytes(content)
+    (tmp_path / "b.squashfs").write_bytes(content)
+
+    call_count = {"n": 0}
+
+    async def fake(src, out_dir, timeout):
+        call_count["n"] += 1
+        os.makedirs(out_dir, exist_ok=True)
+        (Path(out_dir) / "marker").write_text("extracted")
+        return True, "fake ok"
+
+    _install_fake_extractor(monkeypatch, fake)
+
+    log = await recursive_extract(str(tmp_path))
+    assert call_count["n"] == 1, f"expected 1 extraction, got {call_count['n']}"
+    assert "iter 1: 1 candidate" in log or "iter 1: 2 candidate" in log
+
+
+@pytest.mark.asyncio
+async def test_loop_terminates_when_no_new_images(tmp_path: Path, monkeypatch):
+    (tmp_path / "one.squashfs").write_bytes(b"hsqs" + b"\x01" * MIN_SIZE)
+
+    async def fake(src, out_dir, timeout):
+        # Extract to a directory, but don't produce any new filesystem images.
+        os.makedirs(out_dir, exist_ok=True)
+        (Path(out_dir) / "hello.txt").write_text("payload")
+        return True, "fake ok"
+
+    _install_fake_extractor(monkeypatch, fake)
+
+    log = await recursive_extract(str(tmp_path), max_depth=5)
+    # Loop should stop at iter 2 because iter 2 finds no new candidates.
+    assert "iter 2: no new images; stopping" in log
+
+
+@pytest.mark.asyncio
+async def test_max_depth_caps_runaway(tmp_path: Path, monkeypatch):
+    # Extractor keeps producing a fresh squashfs image each iteration —
+    # a pathological case we must terminate.
+    counter = {"n": 0}
+
+    async def fake(src, out_dir, timeout):
+        counter["n"] += 1
+        os.makedirs(out_dir, exist_ok=True)
+        # Emit a new squashfs blob with unique content so SHA dedup doesn't
+        # save us — only max_depth should.
+        (Path(out_dir) / f"nested-{counter['n']}.squashfs").write_bytes(
+            b"hsqs" + bytes([counter["n"]]) * MIN_SIZE
+        )
+        return True, "fake ok"
+
+    _install_fake_extractor(monkeypatch, fake)
+
+    (tmp_path / "seed.squashfs").write_bytes(b"hsqs" + b"\x42" * MIN_SIZE)
+
+    log = await recursive_extract(str(tmp_path), max_depth=3)
+    assert "reached max_depth=3" in log
+    assert counter["n"] == 3
+
+
+@pytest.mark.asyncio
+async def test_extractor_exception_is_logged_not_raised(tmp_path: Path, monkeypatch):
+    (tmp_path / "bad.squashfs").write_bytes(b"hsqs" + b"\x00" * MIN_SIZE)
+
+    async def fake(src, out_dir, timeout):
+        raise RuntimeError("simulated extractor crash")
+
+    _install_fake_extractor(monkeypatch, fake)
+
+    log = await recursive_extract(str(tmp_path))
+    assert "exception" in log
+    assert "simulated extractor crash" in log
+
+
+@pytest.mark.asyncio
+async def test_size_cap_halts_extraction(tmp_path: Path, monkeypatch):
+    (tmp_path / "a.squashfs").write_bytes(b"hsqs" + b"\x01" * MIN_SIZE)
+    (tmp_path / "b.squashfs").write_bytes(b"hsqs" + b"\x02" * MIN_SIZE)
+    (tmp_path / "c.squashfs").write_bytes(b"hsqs" + b"\x03" * MIN_SIZE)
+
+    async def fake(src, out_dir, timeout):
+        os.makedirs(out_dir, exist_ok=True)
+        # Emit a huge payload (10 MB) per extraction.
+        (Path(out_dir) / "big").write_bytes(b"\x00" * (10 * 1024 * 1024))
+        return True, "fake ok"
+
+    _install_fake_extractor(monkeypatch, fake)
+
+    # original_size=1 MB, multiplier=5 → cap at 5 MB. The first extraction
+    # (10 MB) exceeds the cap, so subsequent candidates are skipped.
+    log = await recursive_extract(
+        str(tmp_path),
+        original_size=1024 * 1024,
+        max_total_bytes_multiplier=5.0,
+    )
+    assert "size cap hit" in log
+
+
+@pytest.mark.asyncio
+async def test_no_candidates_returns_clean_log(tmp_path: Path):
+    # Empty extraction dir — dispatcher should be a no-op.
+    log = await recursive_extract(str(tmp_path))
+    assert "no new images; stopping" in log
+    assert "[fs_extractors] done" in log
+
+
+@pytest.mark.asyncio
+async def test_yaffs_images_are_reported(tmp_path: Path):
+    (tmp_path / "firmware.yaffs2").write_bytes(b"\x00" * MIN_SIZE)
+    log = await recursive_extract(str(tmp_path))
+    assert "YAFFS image(s) detected" in log


### PR DESCRIPTION
## Summary
- Enables binwalk matryoshka mode (`-Me -d 5`, 1800s timeout) for deeper first-pass extraction.
- Adds `fs_extractors.py`: a post-binwalk dispatcher that detects SquashFS, UBI, UBIFS, JFFS2, CramFS, ext2/3/4, and cpio images by magic bytes and extracts them with `unsquashfs` (sasquatch fallback for vendor-modified SquashFS like Zyxel/D-Link), `ubireader_extract_images/_files`, `jefferson`, `cramfsck`, `7z`, and `cpio`.
- Loops until fixed-point (max_depth=3) with SHA256 dedup; guards against extraction bombs via per-extraction timeout and a cumulative-size cap based on original firmware size. Skips kernels, large ELFs, and symlinks escaping the extraction root. YAFFS images are logged as manual-extraction candidates. All failures log-and-continue — the dispatcher never fails the overall unpack.

## Test plan
- [ ] `cd backend && uv run pytest tests/test_fs_extractors.py -v` passes
- [ ] Upload firmware with a vendor-modified SquashFS (Zyxel/D-Link) and verify sasquatch fallback path extracts successfully
- [ ] Upload firmware with UBI/JFFS2 images and verify nested filesystems are unpacked
- [ ] Verify `firmware.unpack_log` contains the `[fs_extractors]` dispatcher output
- [ ] Confirm the overall unpack still succeeds when optional tools (sasquatch, jefferson, ubireader) are missing