### PR TITLE
fix(docker): remove cpus limits that require CFS scheduler support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,7 +78,6 @@ services:
       resources:
         limits:
           memory: 1024M
-          cpus: "1.0"
 
   fuzzing:
     build:
@@ -93,7 +92,6 @@ services:
       resources:
         limits:
           memory: 2048M
-          cpus: "2.0"
 
   frontend:
     build:


### PR DESCRIPTION
## Summary
- Removed `cpus:` directives from emulation and fuzzing services in docker-compose.yml
- These required kernel CFS scheduler support, which isn't available on all platforms (WSL2, custom kernels), blocking `docker compose up` entirely
- Memory limits remain in place as the important safety guards

Closes #15

## Test plan
- [ ] `docker compose up` succeeds on a system without CFS scheduler support
- [ ] Emulation and fuzzing containers still respect memory limits

🤖 Generated with [Claude Code](https://claude.com/claude-code)