### PR TITLE
fix(frontend): resolve backend upstream at runtime to avoid DNS race

### DIFF
--- a/frontend/nginx.conf.template
+++ b/frontend/nginx.conf.template
@@ -6,7 +6,9 @@ server {
     client_max_body_size ${MAX_UPLOAD_SIZE_MB}M;
 
     location /api/ {
-        proxy_pass http://backend:8000;
+        resolver 127.0.0.11 valid=30s;
+        set $backend_upstream http://backend:8000;
+        proxy_pass $backend_upstream;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
## Summary
- Frontend nginx container crashed on startup when backend DNS wasn't immediately resolvable (common on Docker Desktop for Mac)
- Use Docker's internal DNS resolver (`127.0.0.11`) with a variable-based `proxy_pass` so nginx resolves `backend` at request time instead of boot time
- Frontend now starts reliably regardless of backend readiness

Credit to @meetinthemiddle-be for the root cause analysis and proposed fix in the issue.

Closes #10

## Test plan
- [ ] `docker compose up -d` — frontend container stays running even if backend is still migrating
- [ ] API requests proxied correctly once backend is ready
- [ ] WebSocket connections still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)