### PR TITLE
fix(import): improve error message when uploading firmware to import

### DIFF
--- a/backend/app/routers/export_import.py
+++ b/backend/app/routers/export_import.py
@@ -65,7 +65,9 @@ async def import_project(
     ):
         raise HTTPException(
             400,
-            "Invalid file type. Please upload a .wairz archive.",
+            "Invalid file type. Please upload a .wairz archive (exported from another "
+            "Wairz instance). To analyze a firmware file (.bin, .img, .trx, etc.), "
+            "use 'New Project' and upload it there instead.",
         )
 
     contents = await file.read()


### PR DESCRIPTION
## Summary
- Users confused the Import button (for .wairz project archives) with firmware upload, getting an unhelpful "Invalid file type. Please upload a .wairz archive." error
- The new message explains that Import is for .wairz archives exported from another Wairz instance, and directs users to "New Project" for firmware files (.bin, .img, .trx, etc.)

Closes #12

## Test plan
- [ ] Try importing a non-.wairz file — error message now explains the distinction and suggests "New Project"
- [ ] Valid .wairz import still works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)