### PR TITLE
fix(import): fix 404 race condition and timezone mismatch on import

### DIFF
--- a/backend/app/routers/export_import.py
+++ b/backend/app/routers/export_import.py
@@ -80,8 +80,11 @@ async def import_project(
     except ValueError as e:
         raise HTTPException(400, str(e))
 
-    # Flush to ensure all records are written, then reload with firmware relationship
-    await db.flush()
+    # Commit before returning so the project is visible to other sessions
+    # immediately. Without this, the get_db dependency commits after the
+    # response is sent, causing a race where the frontend navigates to
+    # the new project page before the data is committed.
+    await db.commit()
     result = await db.execute(
         select(Project)
         .where(Project.id == project.id)

--- a/backend/app/services/import_service.py
+++ b/backend/app/services/import_service.py
@@ -7,7 +7,7 @@ import os
 import stat
 import uuid
 import zipfile
-from datetime import datetime
+from datetime import datetime, timezone
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -24,15 +24,27 @@ from app.services.export_service import ARCHIVE_VERSION
 
 
 def _parse_dt(val) -> datetime | None:
-    """Parse an ISO datetime string or return None."""
+    """Parse an ISO datetime string or return None.
+
+    Always returns a timezone-naive datetime (UTC) to match the DB column
+    types (TIMESTAMP WITHOUT TIME ZONE). Exported archives may contain
+    timezone-aware ISO strings (e.g. "2026-04-15T06:05:48+00:00") that
+    would cause asyncpg to raise "can't subtract offset-naive and
+    offset-aware datetimes" if passed directly.
+    """
     if val is None:
         return None
     if isinstance(val, datetime):
-        return val
-    try:
-        return datetime.fromisoformat(val)
-    except (TypeError, ValueError):
-        return None
+        dt = val
+    else:
+        try:
+            dt = datetime.fromisoformat(val)
+        except (TypeError, ValueError):
+            return None
+    # Convert to UTC and strip timezone info for asyncpg compatibility
+    if dt.tzinfo is not None:
+        dt = dt.astimezone(timezone.utc).replace(tzinfo=None)
+    return dt
 
 
 class ImportService:


### PR DESCRIPTION
## Summary
Fixes both bugs reported in #24:

1. **404 after import** — The `get_db` yield dependency commits the transaction *after* the response is sent. The frontend received the new project ID, navigated to it, but the GET request hit a different session that couldn't see the uncommitted data. Fixed by calling `db.commit()` explicitly in the import endpoint before returning.

2. **HTTP 500 timezone error** — Exported archives contain timezone-aware ISO datetime strings (e.g. `2026-04-15T06:05:48+00:00`) but the DB uses `TIMESTAMP WITHOUT TIME ZONE`. asyncpg raised `TypeError: can't subtract offset-naive and offset-aware datetimes`. Fixed `_parse_dt` to convert to UTC and strip timezone info.

Closes #24

## Test plan
- [ ] Import a .wairz archive — project page loads immediately without 404
- [ ] Import an archive with timezone-aware datetime fields — no HTTP 500
- [ ] Import consecutively (2-3 times) — all imports navigate correctly
- [ ] Export then re-import a project with fuzzing campaigns and SBOM data — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)