### PR TITLE
fix(docker): build Ghidra native components on ARM64

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -65,6 +65,24 @@ RUN wget -q "https://github.com/NationalSecurityAgency/ghidra/releases/download/
     && mv /opt/ghidra_${GHIDRA_VERSION}_PUBLIC /opt/ghidra \
     && rm /tmp/ghidra.zip
 
+# Build Ghidra native components on ARM64 (decompiler, sleigh, demangler).
+# The pre-built Ghidra release only ships x86_64 Linux binaries. On ARM64
+# (e.g. Apple Silicon Macs running Docker), the decompiler is missing,
+# breaking decompilation, dataflow tracing, and string ref resolution.
+# The Gradle build system included in the distribution handles this.
+RUN if [ "$(uname -m)" = "aarch64" ]; then \
+        echo "ARM64 detected — building Ghidra native components..." \
+        && apt-get update && apt-get install -y --no-install-recommends flex bison \
+        && rm -rf /var/lib/apt/lists/* \
+        && cd /opt/ghidra/support/gradle \
+        && chmod +x gradlew \
+        && JAVA_HOME=/usr/lib/jvm/java-21-openjdk-arm64 \
+           ./gradlew buildNatives \
+        && echo "Ghidra native build complete for ARM64"; \
+    else \
+        echo "x86_64 detected — using pre-built Ghidra natives"; \
+    fi
+
 # Install uv
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 


### PR DESCRIPTION
## Summary
- Pre-built Ghidra release only ships x86_64 Linux native binaries
- On ARM64 (Apple Silicon Macs, ARM servers), the decompiler is missing, breaking `decompile_function`, `find_string_refs`, and `trace_dataflow`
- Added a conditional Dockerfile step that detects ARM64 (`uname -m = aarch64`) and builds native components using Ghidra's included Gradle build system
- No-op on x86_64 — existing builds are unaffected

Closes #13

## Details
Ghidra's binary distribution includes Gradle build support and the C++ source for all native components (decompiler, sleigh, demangler). The `nativePlatforms.gradle` already defines `linux_arm_64` as a supported platform. This step just runs `gradlew buildNatives` from the distribution's `support/gradle/` directory, which compiles the native binaries for the current platform.

Additional build dependencies added (ARM64 only): `flex`, `bison` (C++ compiler already present via `build-essential`).

## Test plan
- [ ] Build on x86_64 — no change, step prints "using pre-built Ghidra natives"
- [ ] Build on ARM64 — step builds native components, `os/linux_arm_64/decompile` exists after build
- [ ] On ARM64: `decompile_function` MCP tool works on a MIPS binary
- [ ] On ARM64: `find_string_refs` MCP tool works

**Needs testing on ARM64 hardware** — @meetinthemiddle-be could you test this on your M1 Mac setup?

🤖 Generated with [Claude Code](https://claude.com/claude-code)