### PR TITLE
Add RTOS firmware support (FreeRTOS / Zephyr / baremetal-Cortex-M)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,9 @@ wairz/
 1. Create or edit a handler in `backend/app/ai/tools/<category>.py`:
    ```python
    async def _handle_my_tool(input: dict, context: ToolContext) -> str:
-       # Available on context: project_id, firmware_id, extracted_path, db
+       # Available on context: project_id, firmware_id, extracted_path,
+       # storage_path (for RTOS / blob-only firmware), extraction_dir,
+       # carved_path, db
        path = context.resolve_path(input.get("path", "/"))  # validates against sandbox
        # ... do work ...
        return "result string (max 30KB, truncated automatically)"
@@ -102,7 +104,16 @@ wairz/
    ```python
    registry.register(name="my_tool", description="...", input_schema={...}, handler=_handle_my_tool)
    ```
-3. If it's a new category file, import and call `register_<category>_tools(registry)` in `backend/app/ai/__init__.py`.
+3. **Tag kind-specific tools** via `applies_to`. Defaults to `ALL_KINDS` (`("linux", "rtos", "unknown")`); only set this when the tool *requires* something one kind has and another doesn't:
+   ```python
+   registry.register(
+       name="enumerate_rtos_tasks",
+       description="...", input_schema={...}, handler=_handle_enumerate_rtos_tasks,
+       applies_to=("rtos",),   # hidden from list_tools when active project is Linux
+   )
+   ```
+   The MCP server filters `list_tools` by the active firmware's kind and rejects mismatched `call_tool` invocations as defense in depth. `switch_project` emits `notifications/tools/list_changed` so clients re-fetch automatically.
+4. If it's a new category file, import and call `register_<category>_tools(registry)` in `backend/app/ai/__init__.py`.
 
 ### Adding a New REST Endpoint
 
@@ -161,9 +172,22 @@ wairz/
 
 Entry point: `wairz-mcp = "app.mcp_server:main"` (defined in `pyproject.toml`)
 
-The server uses a mutable `ProjectState` dataclass so all project context (project_id, firmware_id, extracted_path) can be switched dynamically via the `switch_project` tool without restarting the MCP process.
+The server uses a mutable `ProjectState` dataclass so all project context (project_id, firmware_id, extracted_path, storage_path, firmware_kind, rtos_flavor) can be switched dynamically via the `switch_project` tool without restarting the MCP process. When the firmware kind changes, the server emits `notifications/tools/list_changed` so clients re-fetch the visible tool set.
 
-### Tool Categories (60+)
+### Firmware kind discriminator
+
+Every `firmware` row carries `firmware_kind` (`linux | rtos | unknown`) plus an optional `rtos_flavor` (`freertos | zephyr | baremetal-cortexm`) and `firmware_kind_source` (`detected | manual`). Auto-detection runs in `app/services/rtos_detection_service.py` at the tail of unpack and only writes when `firmware_kind_source != 'manual'` — the dropdown override on the project page always wins. Kind plumbs through to the MCP system prompt (kind-aware blocks in `app/ai/system_prompt.py`), the tool registry filter (`registry.for_kind(kind)`), and the frontend (`Project.firmware_kind` from the projects-list endpoint, used by Sidebar to filter analysis tabs).
+
+### Path resolution for RTOS firmware
+
+RTOS projects have no `extracted_path` (no rootfs to mount). `FileService` recognises this "blob-only" mode and exposes the firmware blob via:
+
+- `/firmware/<basename>` — the canonical virtual path
+- `/<basename>` and bare `<basename>` — also resolve, for forgiving callers
+
+Tools that take a `binary_path` / `path` argument and call `context.resolve_path()` work transparently across Linux and RTOS; `context.storage_path` is the underlying real path when an RTOS-specific tool needs to bypass the virtual layer (e.g. `enumerate_rtos_tasks` uses pyelftools directly on it).
+
+### Tool Categories (90+)
 
 | Category | File | Tools |
 |----------|------|-------|
@@ -179,6 +203,9 @@ The server uses a mutable `ProjectState` dataclass so all project context (proje
 | UART | `tools/uart.py` | `uart_connect`, `uart_send_command`, `uart_read`, `uart_send_break`, `uart_send_raw`, `uart_disconnect`, `uart_status`, `uart_get_transcript` |
 | Reporting | `tools/reporting.py` | `add_finding`, `list_findings`, `update_finding`, `read_project_instructions`, `list_project_documents`, `read_project_document` |
 | Code | `tools/documents.py` | `save_code_cleanup` |
+| RTOS *(applies_to=`("rtos",)`)* | `tools/rtos.py` | `detect_rtos_kernel`, `enumerate_rtos_tasks`, `analyze_vector_table`, `recover_base_address`, `analyze_memory_map` |
+
+Linux-only tools are tagged `applies_to=("linux",)` in `tools/emulation.py` (15 tools), `tools/security.py` (4 of the 6 — `analyze_config_security`, `check_setuid_binaries`, `analyze_init_scripts`, `check_filesystem_permissions`), and `tools/filesystem.py` (`get_component_map`). All other tools default to `ALL_KINDS`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Connect any MCP-compatible AI agent to Wairz's 60+ analysis tools — [Claude Co
 ## Features
 
 - **Firmware Unpacking** — Automatic extraction of SquashFS, JFFS2, UBIFS, CramFS, ext, and CPIO filesystems via binwalk, with multi-partition support
+- **RTOS Support** — Auto-classifies firmware as `linux | rtos | unknown` on unpack (FreeRTOS / Zephyr / baremetal Cortex-M), with manual override. RTOS projects get a dedicated tool category for vector-table parsing, task enumeration, base-address recovery, and memory-map analysis on raw `.axf` / `.elf` blobs
 - **File Explorer** — Browse extracted filesystems with a virtual tree, view text/binary/hex content, and search across files
 - **Binary Analysis** — Disassemble and decompile binaries using radare2 and Ghidra headless, with cross-reference and taint analysis
 - **Component Map** — Interactive dependency graph showing binaries, libraries, scripts, and their relationships
@@ -59,7 +60,7 @@ Optional:
 
 WAIRZ is currently in **public beta**. You may encounter bugs or rough edges. If you run into any issues, please [open an issue on GitHub](https://github.com/digitalandrew/wairz/issues) or reach out at andrew@digitalandrew.io.
 
-WAIRZ is currently designed for **embedded Linux** firmware samples. Support for RTOS and bare-metal firmware is planned for future releases.
+WAIRZ supports **embedded Linux**, **FreeRTOS**, **Zephyr**, and **baremetal Cortex-M** firmware. Auto-detection runs on unpack and can be overridden from the project page. Linux-specific tools (emulation, init-script analysis, SBOM, etc.) are hidden on RTOS projects, and a dedicated RTOS tool category is exposed in their place. See [RTOS support](docs/features/rtos.md) for details.
 
 ## Quick Start
 

--- a/backend/alembic/versions/d5e6f7a8b9c0_add_firmware_kind.py
+++ b/backend/alembic/versions/d5e6f7a8b9c0_add_firmware_kind.py
@@ -1,0 +1,50 @@
+"""add firmware_kind, firmware_kind_source, rtos_flavor
+
+Revision ID: d5e6f7a8b9c0
+Revises: c4d5e6f7a8b9
+Create Date: 2026-05-01 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "d5e6f7a8b9c0"
+down_revision: Union[str, None] = "c4d5e6f7a8b9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "firmware",
+        sa.Column(
+            "firmware_kind",
+            sa.String(20),
+            nullable=False,
+            server_default="unknown",
+        ),
+    )
+    op.add_column(
+        "firmware",
+        sa.Column("firmware_kind_source", sa.String(20), nullable=True),
+    )
+    op.add_column(
+        "firmware",
+        sa.Column("rtos_flavor", sa.String(40), nullable=True),
+    )
+
+    # Backfill: every existing project today is embedded Linux. Tag them as
+    # detected=linux so the UI can show the source as auto-detected (and the
+    # user can still override). Phase 4's auto-detector will refine these.
+    op.execute(
+        "UPDATE firmware SET firmware_kind = 'linux', firmware_kind_source = 'detected'"
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("firmware", "rtos_flavor")
+    op.drop_column("firmware", "firmware_kind_source")
+    op.drop_column("firmware", "firmware_kind")

--- a/backend/app/ai/__init__.py
+++ b/backend/app/ai/__init__.py
@@ -7,6 +7,7 @@ from app.ai.tools.emulation import register_emulation_tools
 from app.ai.tools.fuzzing import register_fuzzing_tools
 from app.ai.tools.filesystem import register_filesystem_tools
 from app.ai.tools.reporting import register_reporting_tools
+from app.ai.tools.rtos import register_rtos_tools
 from app.ai.tools.sbom import register_sbom_tools
 from app.ai.tools.security import register_security_tools
 from app.ai.tools.strings import register_string_tools
@@ -28,4 +29,5 @@ def create_tool_registry() -> ToolRegistry:
     register_comparison_tools(registry)
     register_uart_tools(registry)
     register_carving_tools(registry)
+    register_rtos_tools(registry)
     return registry

--- a/backend/app/ai/system_prompt.py
+++ b/backend/app/ai/system_prompt.py
@@ -1,58 +1,52 @@
-def build_system_prompt(
-    project_name: str,
-    firmware_filename: str,
-    architecture: str | None,
-    endianness: str | None,
-    extracted_path: str,
-) -> str:
-    """Build the system prompt for the AI firmware analyst."""
-    arch_info = architecture or "unknown"
-    endian_info = endianness or "unknown"
+# Knowledge / triage / emulation blocks vary by firmware kind. Linux blocks
+# preserve the prompt that shipped before RTOS support was added; the RTOS
+# blocks reflect what changes in an MMU-less, single-binary environment.
 
-    prompt = f"""\
-You are Wairz AI, an expert firmware reverse engineer and security analyst.
-You are analyzing firmware for project: {project_name}
-Firmware: {firmware_filename} ({arch_info}, {endian_info})
-Extracted filesystem root: {extracted_path}
-
-Your role:
-- Help the user with whatever they ask regarding this firmware
-- Answer the specific question or perform the specific task the user requests
-- When you find security issues during your work, use add_finding to formally record them
-- Explain your reasoning as you work
-- If you are unsure about something, say so rather than guessing
-
-IMPORTANT — Stay focused on the user's request:
-- Do ONLY what the user asks. When you have answered their question or completed their task, STOP.
-- Do NOT launch into a broader security review, filesystem survey, or vulnerability scan unless the user explicitly asks for one.
-- Do NOT continue investigating tangential findings after finishing the requested task.
-- If you notice something interesting while working, briefly mention it and let the user decide whether to pursue it.
-
+_LINUX_KNOWLEDGE = """\
 Knowledge reference (use when relevant to the user's question):
 - Common embedded Linux vulnerability classes: hardcoded credentials, insecure network services, missing binary protections, known vulnerable components, leftover debug interfaces, weak file permissions, unencrypted sensitive data
-- Key areas to check: startup scripts, custom daemons, web servers, config files, setuid binaries
+- Key areas to check: startup scripts, custom daemons, web servers, config files, setuid binaries"""
 
-SBOM & vulnerability scanning:
-- Use generate_sbom to identify software components (packages, libraries, kernel) in the firmware
-- Use run_vulnerability_scan to check all identified components against the NVD for known CVEs
-- Findings from vulnerability scans are auto-created with source='sbom_scan'
-- Use check_component_cves for targeted CVE lookup on a specific component+version
-- The SBOM scan is a good starting point for security assessments — it reveals inherited risks from third-party components
+_RTOS_KNOWLEDGE_TEMPLATE = """\
+Knowledge reference (use when relevant to the user's question):
+- This is an RTOS firmware{flavor_suffix}. It is typically a single binary running in a single address space with no MMU and no Linux-style filesystem. Linux-shaped tools (init scripts, setuid checks, filesystem permissions, /etc/passwd, QEMU Linux emulation, component map) do not apply and are filtered from your tool list.
+- Common RTOS vulnerability classes:
+  - Memory-safety bugs in parsers — RTOS targets typically lack ASLR, NX, and stack canaries; a single overflow often gives full control of the device
+  - Hardcoded credentials, certificates, and keys baked into flash
+  - Weak or broken crypto: custom ciphers, hardcoded IVs/keys, broken TLS verification
+  - OTA update verification flaws — missing or weak signature checks, version rollback, plaintext images
+  - Debug interfaces left enabled in production: UART login shell, JTAG/SWD, semihosting, vendor diagnostic commands
+  - Single address space — any task can read/write any memory, so an info-disclosure bug can leak crypto material from another task
+  - Vendor-bundled networking stacks (lwIP, mbedTLS, MQTT clients, FreeRTOS+TCP, Zephyr net, etc.) — check bundled versions for known CVEs
+- Key areas to investigate:
+  - Network parsers and protocol handlers (HTTP, MQTT, CoAP, custom binary protocols)
+  - Bootloader and OTA update code paths
+  - Strings dump for hardcoded credentials, debug commands, and diagnostic backdoors
+  - Vendor library versions (look for version strings in the binary) for CVE matching
+  - Decompile main(), task entry points, and any handler that touches untrusted input"""
 
-Vulnerability assessment & triage:
-- After a vulnerability scan, use list_vulnerabilities_for_assessment to review CVEs in batches
-- Use assess_vulnerabilities to batch-adjust severity and/or resolve CVEs based on device context
-- NVD baseline scores (cvss_score, severity) are always preserved — adjustments go into adjusted_cvss_score, adjusted_severity
+_UNKNOWN_KNOWLEDGE = """\
+Knowledge reference (use when relevant to the user's question):
+- The firmware kind for this project has not been classified yet (firmware_kind='unknown'). Linux-specific and RTOS-specific tools are both filtered out — only kind-agnostic tools (binary analysis, strings, UART, fuzzing, CVE checks) are available.
+- Start with reconnaissance to determine what kind of firmware this is: examine strings, look at binary metadata, check for filesystem-shaped layout vs. a single monolithic binary. Once classified, the user can update the kind in the Wairz UI to unlock the appropriate tool surface."""
+
+_LINUX_TRIAGE = """\
 - Common embedded Linux triage patterns:
   - Local privilege escalation CVEs are often lower risk when everything runs as root anyway
   - GUI/desktop-related CVEs (X11, Wayland, GNOME, etc.) are false positives on headless devices
   - Kernel CVEs for subsystems not compiled in (Bluetooth, USB gadget, specific filesystems) can be marked false_positive
   - Network-facing CVEs in components actually exposed (httpd, sshd, DNS) remain high priority
-  - DoS CVEs in user-facing services may be lower severity on embedded devices with watchdog reboot
-- When assessing, always provide a rationale explaining why the severity was adjusted or why the CVE was resolved/ignored
-- Process CVEs in batches of up to 50 using list_vulnerabilities_for_assessment (with offset for pagination) and assess_vulnerabilities
-- Resolution statuses: open (default), resolved (addressed/mitigated), ignored (not relevant), false_positive (does not apply to this device)
+  - DoS CVEs in user-facing services may be lower severity on embedded devices with watchdog reboot"""
 
+_RTOS_TRIAGE = """\
+- Common RTOS triage patterns:
+  - Memory-safety CVEs in bundled libraries (lwIP, mbedTLS, FreeRTOS+TCP, etc.) are usually exploitable on RTOS — there is no ASLR/NX/stack canary to mitigate
+  - Linux-specific CVEs (LPE in Linux kernel subsystems, X11, desktop libs, container escapes) are false positives — RTOS does not run that code
+  - Filesystem-format CVEs (ext4, NFS, FAT parsers in the Linux kernel) are false positives unless the RTOS itself parses those formats (rare)
+  - OTA / update-channel CVEs are high priority — they often allow persistent compromise that survives reboot
+  - DoS CVEs may matter MORE on RTOS than on Linux: a single crashed task can take down the device with no init/systemd to restart it"""
+
+_LINUX_EMULATION = """\
 Emulation capabilities:
 - You can start QEMU-based emulation to dynamically test the firmware
 - User mode: run a single binary in a chroot (fast, good for testing specific programs)
@@ -109,8 +103,92 @@ Emulation troubleshooting — follow this workflow when emulation fails:
    - Run basic commands: 'ls /', 'cat /etc/passwd', 'ls /bin/' to verify the filesystem
    - Manually start individual services: '/usr/sbin/httpd &' rather than relying on full init
    - Check what's listening: 'netstat -tlnp' or parse /proc/net/tcp if netstat is unavailable
-5. If all else fails, fall back to user-mode emulation for testing individual binaries
+5. If all else fails, fall back to user-mode emulation for testing individual binaries"""
 
+_RTOS_EMULATION_NOTE = """\
+Emulation:
+- QEMU Linux emulation does not apply to this RTOS firmware and is not exposed.
+- RTOS-aware emulation (Renode, QEMU Cortex-M with peripheral models) is planned but not yet available in Wairz. For now, focus on static analysis (decompilation, strings, CVE checks) and live UART interaction with real hardware."""
+
+
+def build_system_prompt(
+    project_name: str,
+    firmware_filename: str,
+    architecture: str | None,
+    endianness: str | None,
+    extracted_path: str,
+    firmware_kind: str = "linux",
+    rtos_flavor: str | None = None,
+) -> str:
+    """Build the system prompt for the AI firmware analyst.
+
+    The prompt's knowledge, triage, and emulation sections branch on
+    *firmware_kind* so the agent isn't primed to use tools or strategies
+    that don't apply (e.g. setuid analysis on an RTOS image, or QEMU
+    Linux emulation for a Cortex-M binary). Default kind is "linux" to
+    preserve behavior for callers that haven't been updated.
+    """
+    arch_info = architecture or "unknown"
+    endian_info = endianness or "unknown"
+
+    if firmware_kind == "rtos" and rtos_flavor:
+        kind_label = f"rtos ({rtos_flavor})"
+    else:
+        kind_label = firmware_kind
+
+    if firmware_kind == "rtos":
+        flavor_suffix = f" ({rtos_flavor})" if rtos_flavor else ""
+        knowledge_block = _RTOS_KNOWLEDGE_TEMPLATE.format(flavor_suffix=flavor_suffix)
+        triage_block = _RTOS_TRIAGE
+        emulation_block = _RTOS_EMULATION_NOTE
+    elif firmware_kind == "linux":
+        knowledge_block = _LINUX_KNOWLEDGE
+        triage_block = _LINUX_TRIAGE
+        emulation_block = _LINUX_EMULATION
+    else:
+        knowledge_block = _UNKNOWN_KNOWLEDGE
+        triage_block = _LINUX_TRIAGE  # benign fallback — patterns are general security-engineering wisdom
+        emulation_block = ""  # no emulation guidance until kind is known
+
+    header = f"""\
+You are Wairz AI, an expert firmware reverse engineer and security analyst.
+You are analyzing firmware for project: {project_name}
+Firmware: {firmware_filename} ({arch_info}, {endian_info})
+Kind: {kind_label}
+Extracted filesystem root: {extracted_path}
+
+Your role:
+- Help the user with whatever they ask regarding this firmware
+- Answer the specific question or perform the specific task the user requests
+- When you find security issues during your work, use add_finding to formally record them
+- Explain your reasoning as you work
+- If you are unsure about something, say so rather than guessing
+
+IMPORTANT — Stay focused on the user's request:
+- Do ONLY what the user asks. When you have answered their question or completed their task, STOP.
+- Do NOT launch into a broader security review, filesystem survey, or vulnerability scan unless the user explicitly asks for one.
+- Do NOT continue investigating tangential findings after finishing the requested task.
+- If you notice something interesting while working, briefly mention it and let the user decide whether to pursue it."""
+
+    sbom = """\
+SBOM & vulnerability scanning:
+- Use generate_sbom to identify software components (packages, libraries, kernel) in the firmware
+- Use run_vulnerability_scan to check all identified components against the NVD for known CVEs
+- Findings from vulnerability scans are auto-created with source='sbom_scan'
+- Use check_component_cves for targeted CVE lookup on a specific component+version
+- The SBOM scan is a good starting point for security assessments — it reveals inherited risks from third-party components"""
+
+    triage = f"""\
+Vulnerability assessment & triage:
+- After a vulnerability scan, use list_vulnerabilities_for_assessment to review CVEs in batches
+- Use assess_vulnerabilities to batch-adjust severity and/or resolve CVEs based on device context
+- NVD baseline scores (cvss_score, severity) are always preserved — adjustments go into adjusted_cvss_score, adjusted_severity
+{triage_block}
+- When assessing, always provide a rationale explaining why the severity was adjusted or why the CVE was resolved/ignored
+- Process CVEs in batches of up to 50 using list_vulnerabilities_for_assessment (with offset for pagination) and assess_vulnerabilities
+- Resolution statuses: open (default), resolved (addressed/mitigated), ignored (not relevant), false_positive (does not apply to this device)"""
+
+    uart = """\
 UART serial console (live device interaction):
 - The UART tools let you interact with a physical device's serial console through a host-side bridge
 - Architecture: USB-UART adapter → host machine → wairz-uart-bridge.py (TCP:9999) → Docker backend → MCP tools
@@ -130,8 +208,9 @@ If uart_connect or uart_status returns "Bridge unreachable", instruct the user t
 4. After changing .env, restart the backend: docker compose restart backend
 5. After restarting the backend, the user must reconnect MCP (e.g. /mcp in Claude Code)
 
-Once connected, use uart_send_command for interactive shell commands, uart_read for passive output capture (boot logs), and uart_send_break to interrupt U-Boot autoboot. Always uart_disconnect when done.
+Once connected, use uart_send_command for interactive shell commands, uart_read for passive output capture (boot logs), and uart_send_break to interrupt U-Boot autoboot. Always uart_disconnect when done."""
 
+    fuzzing = """\
 Automated fuzzing:
 - Use AFL++ in QEMU mode to automatically discover crashes in firmware binaries
 - Workflow: analyze_fuzzing_target → generate_fuzzing_dictionary → generate_seed_corpus → start_fuzzing_campaign → check_fuzzing_status → triage_fuzzing_crash → add_finding
@@ -140,14 +219,16 @@ Automated fuzzing:
 - Generate a dictionary (from binary strings) and seed corpus (based on input type) for better results
 - Only one campaign can run at a time — stop campaigns when done to free resources
 - Triage each crash to determine exploitability before creating findings
-- Use source='fuzzing' when creating findings from fuzzing crashes
+- Use source='fuzzing' when creating findings from fuzzing crashes"""
 
+    output_format = """\
 Output format:
 - Be concise but thorough for the task at hand
 - When showing code or disassembly, highlight the relevant parts
 - Always explain WHY something is a security concern, not just THAT it is
-- Rate findings: critical, high, medium, low, info
+- Rate findings: critical, high, medium, low, info"""
 
+    scratchpad = """\
 Agent scratchpad:
 - The scratchpad (SCRATCHPAD.md) persists your analysis notes across sessions
 - At the start of each session, call read_scratchpad to check for notes from prior sessions
@@ -164,4 +245,14 @@ as they apply to your analysis.
 You have access to the tools defined in this conversation. Use them \
 to investigate as needed for the user's request."""
 
-    return prompt
+    sections = [
+        header,
+        knowledge_block,
+        sbom,
+        triage,
+    ]
+    if emulation_block:
+        sections.append(emulation_block)
+    sections.extend([uart, fuzzing, output_format, scratchpad])
+
+    return "\n\n".join(sections)

--- a/backend/app/ai/tool_registry.py
+++ b/backend/app/ai/tool_registry.py
@@ -27,15 +27,16 @@ class ToolContext:
         """Resolve a virtual firmware path to a real filesystem path.
 
         Handles virtual top-level paths like /rootfs/..., /jffs2-root/...,
-        /_carved/..., etc. when the corresponding root is configured.
-        Falls back to simple validation against extracted_path for legacy
-        (non-virtual) mode.
+        /_carved/..., /firmware/... etc. when the corresponding root is
+        configured. Falls back to simple validation against extracted_path
+        for legacy (non-virtual) mode.
         """
         from app.services.file_service import FileService
         svc = FileService(
             self.extracted_path,
             extraction_dir=self.extraction_dir,
             carved_path=self.carved_path,
+            firmware_path=self.storage_path,
         )
         return svc._resolve(path)
 
@@ -66,6 +67,7 @@ class ToolContext:
             self.extracted_path,
             extraction_dir=self.extraction_dir,
             carved_path=self.carved_path,
+            firmware_path=self.storage_path,
         )
         # Paths inside rootfs
         if not clean or clean == svc.ROOTFS_VNAME or clean.startswith(svc.ROOTFS_VNAME + "/"):
@@ -91,6 +93,7 @@ class ToolContext:
             self.extracted_path,
             extraction_dir=self.extraction_dir,
             carved_path=self.carved_path,
+            firmware_path=self.storage_path,
         )
         return svc.to_virtual_path(abs_path)
 

--- a/backend/app/ai/tool_registry.py
+++ b/backend/app/ai/tool_registry.py
@@ -16,6 +16,10 @@ class ToolContext:
     db: AsyncSession
     extraction_dir: str | None = None
     carved_path: str | None = None
+    # Path to the original firmware blob (e.g. an .axf / .bin). Required by
+    # RTOS tooling because RTOS images don't have a mountable rootfs to
+    # search via extracted_path.
+    storage_path: str | None = None
     review_id: UUID | None = None
     review_agent_id: UUID | None = None
 

--- a/backend/app/ai/tool_registry.py
+++ b/backend/app/ai/tool_registry.py
@@ -91,12 +91,19 @@ class ToolContext:
         return svc.to_virtual_path(abs_path)
 
 
+# Sentinel meaning "this tool applies to every firmware kind". Tools default to
+# this — only tag when the tool is meaningfully kind-specific (e.g. requires a
+# Linux rootfs, or only makes sense for an RTOS image).
+ALL_KINDS: tuple[str, ...] = ("linux", "rtos", "unknown")
+
+
 @dataclass
 class ToolDefinition:
     name: str
     description: str
     input_schema: dict
     handler: Callable[[dict, ToolContext], Awaitable[str]]
+    applies_to: tuple[str, ...] = ALL_KINDS
 
 
 class ToolRegistry:
@@ -109,12 +116,14 @@ class ToolRegistry:
         description: str,
         input_schema: dict,
         handler: Callable[[dict, ToolContext], Awaitable[str]],
+        applies_to: tuple[str, ...] = ALL_KINDS,
     ) -> None:
         self._tools[name] = ToolDefinition(
             name=name,
             description=description,
             input_schema=input_schema,
             handler=handler,
+            applies_to=applies_to,
         )
 
     def subset(self, tool_names: list[str]) -> "ToolRegistry":
@@ -123,6 +132,18 @@ class ToolRegistry:
         for name in tool_names:
             if name in self._tools:
                 new_registry._tools[name] = self._tools[name]
+        return new_registry
+
+    def for_kind(self, kind: str) -> "ToolRegistry":
+        """Return a new ToolRegistry with only the tools that apply to *kind*.
+
+        Tools without an explicit applies_to default to ALL_KINDS and pass
+        through unchanged.
+        """
+        new_registry = ToolRegistry()
+        for name, tool in self._tools.items():
+            if kind in tool.applies_to:
+                new_registry._tools[name] = tool
         return new_registry
 
     def get_anthropic_tools(self) -> list[dict]:

--- a/backend/app/ai/tools/emulation.py
+++ b/backend/app/ai/tools/emulation.py
@@ -43,6 +43,7 @@ def register_emulation_tools(registry: ToolRegistry) -> None:
             },
         },
         handler=_handle_list_kernels,
+        applies_to=("linux",),
     )
 
     registry.register(
@@ -87,6 +88,7 @@ def register_emulation_tools(registry: ToolRegistry) -> None:
             "required": ["url", "name", "architecture"],
         },
         handler=_handle_download_kernel,
+        applies_to=("linux",),
     )
 
     registry.register(
@@ -189,6 +191,7 @@ def register_emulation_tools(registry: ToolRegistry) -> None:
             "required": ["mode"],
         },
         handler=_handle_start_emulation,
+        applies_to=("linux",),
     )
 
     registry.register(
@@ -244,6 +247,7 @@ def register_emulation_tools(registry: ToolRegistry) -> None:
             "required": ["session_id", "command"],
         },
         handler=_handle_run_command,
+        applies_to=("linux",),
     )
 
     registry.register(
@@ -263,6 +267,7 @@ def register_emulation_tools(registry: ToolRegistry) -> None:
             "required": ["session_id"],
         },
         handler=_handle_stop_emulation,
+        applies_to=("linux",),
     )
 
     registry.register(
@@ -282,6 +287,7 @@ def register_emulation_tools(registry: ToolRegistry) -> None:
             },
         },
         handler=_handle_check_status,
+        applies_to=("linux",),
     )
 
     registry.register(
@@ -305,6 +311,7 @@ def register_emulation_tools(registry: ToolRegistry) -> None:
             "required": ["session_id"],
         },
         handler=_handle_get_logs,
+        applies_to=("linux",),
     )
 
     registry.register(
@@ -324,6 +331,7 @@ def register_emulation_tools(registry: ToolRegistry) -> None:
             "properties": {},
         },
         handler=_handle_diagnose_environment,
+        applies_to=("linux",),
     )
 
     registry.register(
@@ -350,6 +358,7 @@ def register_emulation_tools(registry: ToolRegistry) -> None:
             },
         },
         handler=_handle_troubleshoot_emulation,
+        applies_to=("linux",),
     )
 
     registry.register(
@@ -372,6 +381,7 @@ def register_emulation_tools(registry: ToolRegistry) -> None:
             "required": ["session_id"],
         },
         handler=_handle_enumerate_services,
+        applies_to=("linux",),
     )
 
     # ── Core Dumps & GDB Debugging ──
@@ -404,6 +414,7 @@ def register_emulation_tools(registry: ToolRegistry) -> None:
             "required": ["session_id"],
         },
         handler=_handle_get_crash_dump,
+        applies_to=("linux",),
     )
 
     registry.register(
@@ -448,6 +459,7 @@ def register_emulation_tools(registry: ToolRegistry) -> None:
             "required": ["session_id", "gdb_commands"],
         },
         handler=_handle_run_gdb_command,
+        applies_to=("linux",),
     )
 
     # ── Emulation Presets ──
@@ -516,6 +528,7 @@ def register_emulation_tools(registry: ToolRegistry) -> None:
             "required": ["name", "mode"],
         },
         handler=_handle_save_preset,
+        applies_to=("linux",),
     )
 
     registry.register(
@@ -529,6 +542,7 @@ def register_emulation_tools(registry: ToolRegistry) -> None:
             "properties": {},
         },
         handler=_handle_list_presets,
+        applies_to=("linux",),
     )
 
     registry.register(
@@ -551,6 +565,7 @@ def register_emulation_tools(registry: ToolRegistry) -> None:
             },
         },
         handler=_handle_start_from_preset,
+        applies_to=("linux",),
     )
 
 

--- a/backend/app/ai/tools/filesystem.py
+++ b/backend/app/ai/tools/filesystem.py
@@ -636,6 +636,7 @@ def register_filesystem_tools(registry: ToolRegistry) -> None:
             "required": [],
         },
         handler=_handle_get_component_map,
+        applies_to=("linux",),
     )
 
     registry.register(

--- a/backend/app/ai/tools/filesystem.py
+++ b/backend/app/ai/tools/filesystem.py
@@ -119,7 +119,7 @@ def _find_files_by_type(
 
 
 async def _handle_list_directory(input: dict, context: ToolContext) -> str:
-    svc = FileService(context.extracted_path, extraction_dir=context.extraction_dir, carved_path=context.carved_path)
+    svc = FileService(context.extracted_path, extraction_dir=context.extraction_dir, carved_path=context.carved_path, firmware_path=context.storage_path)
     entries, truncated = svc.list_directory(input["path"])
 
     if not entries:
@@ -143,7 +143,7 @@ async def _handle_list_directory(input: dict, context: ToolContext) -> str:
 
 
 async def _handle_read_file(input: dict, context: ToolContext) -> str:
-    svc = FileService(context.extracted_path, extraction_dir=context.extraction_dir, carved_path=context.carved_path)
+    svc = FileService(context.extracted_path, extraction_dir=context.extraction_dir, carved_path=context.carved_path, firmware_path=context.storage_path)
     content = svc.read_file(
         path=input["path"],
         offset=input.get("offset", 0),
@@ -159,7 +159,7 @@ async def _handle_read_file(input: dict, context: ToolContext) -> str:
 
 
 async def _handle_file_info(input: dict, context: ToolContext) -> str:
-    svc = FileService(context.extracted_path, extraction_dir=context.extraction_dir, carved_path=context.carved_path)
+    svc = FileService(context.extracted_path, extraction_dir=context.extraction_dir, carved_path=context.carved_path, firmware_path=context.storage_path)
     info = svc.file_info(input["path"])
 
     lines = [
@@ -179,7 +179,7 @@ async def _handle_file_info(input: dict, context: ToolContext) -> str:
 
 
 async def _handle_search_files(input: dict, context: ToolContext) -> str:
-    svc = FileService(context.extracted_path, extraction_dir=context.extraction_dir, carved_path=context.carved_path)
+    svc = FileService(context.extracted_path, extraction_dir=context.extraction_dir, carved_path=context.carved_path, firmware_path=context.storage_path)
     matches, truncated = svc.search_files(
         pattern=input["pattern"],
         path=input.get("path", "/"),

--- a/backend/app/ai/tools/rtos.py
+++ b/backend/app/ai/tools/rtos.py
@@ -1,0 +1,498 @@
+"""RTOS-specific MCP tools.
+
+These tools are tagged ``applies_to=("rtos",)`` and operate on the raw
+firmware blob (``context.storage_path``) rather than an unpacked rootfs.
+ELF/.axf images get rich analysis via pyelftools; raw .bin images
+degrade gracefully to byte-level heuristics where possible.
+"""
+
+import os
+import struct
+
+from elftools.elf.elffile import ELFFile
+
+from app.ai.tool_registry import ToolContext, ToolRegistry
+from app.services.rtos_detection_service import detect_firmware_kind
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _open_elf(path: str):
+    """Open *path* as an ELFFile if its magic matches; else (None, None)."""
+    try:
+        fh = open(path, "rb")
+    except OSError:
+        return None, None
+    if fh.read(4) != b"\x7fELF":
+        fh.close()
+        return None, None
+    fh.seek(0)
+    try:
+        return ELFFile(fh), fh
+    except Exception:
+        fh.close()
+        return None, None
+
+
+def _storage_path(context: ToolContext) -> str | None:
+    p = context.storage_path
+    if not p or not os.path.isfile(p):
+        return None
+    return p
+
+
+def _seg_perms(flags: int) -> str:
+    return (
+        ("R" if flags & 4 else "-")
+        + ("W" if flags & 2 else "-")
+        + ("X" if flags & 1 else "-")
+    )
+
+
+def _build_symtab(elf) -> dict[int, str]:
+    """Map function-symbol address (thumb bit cleared) to name."""
+    out: dict[int, str] = {}
+    symtab = elf.get_section_by_name(".symtab")
+    if symtab is None:
+        return out
+    for sym in symtab.iter_symbols():
+        addr = sym["st_value"]
+        name = sym.name or ""
+        if not name or not addr:
+            continue
+        out.setdefault(addr & ~1, name)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# detect_rtos_kernel
+# ---------------------------------------------------------------------------
+
+
+async def _handle_detect_rtos_kernel(input: dict, context: ToolContext) -> str:
+    path = _storage_path(context)
+    if path is None:
+        return "Error: firmware blob is unavailable (storage_path missing)."
+    detection = detect_firmware_kind(path, None, None)
+    lines = [
+        f"Kind: {detection.kind}",
+        f"Flavor: {detection.flavor or '(none)'}",
+        f"Notes: {detection.notes}",
+    ]
+    elf, fh = _open_elf(path)
+    if elf is not None:
+        try:
+            lines.append(f"ELF machine: {elf.header.e_machine}")
+            lines.append(
+                f"ELF endianness: {'little' if elf.little_endian else 'big'}"
+            )
+            lines.append(f"ELF entry: 0x{elf.header.e_entry:08x}")
+        finally:
+            fh.close()
+    else:
+        try:
+            lines.append(f"Image size: {os.path.getsize(path)} bytes (raw, non-ELF)")
+        except OSError:
+            pass
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# enumerate_rtos_tasks
+# ---------------------------------------------------------------------------
+
+
+_TASK_NAME_HINTS = ("Task", "Thread", "task", "thread")
+_FREERTOS_INFRA_PREFIX = ("vTask", "xTask", "uxTask", "prv", "xQueue", "xSemaphore")
+
+
+async def _handle_enumerate_rtos_tasks(input: dict, context: ToolContext) -> str:
+    path = _storage_path(context)
+    if path is None:
+        return "Error: firmware blob is unavailable."
+    elf, fh = _open_elf(path)
+    if elf is None:
+        return (
+            "enumerate_rtos_tasks requires an ELF image (.axf/.elf). "
+            "This firmware is a raw binary — task enumeration is not supported "
+            "without symbol metadata."
+        )
+    try:
+        symtab = elf.get_section_by_name(".symtab")
+        if symtab is None:
+            return (
+                "ELF has no .symtab — image is stripped. Cannot enumerate "
+                "tasks symbolically. Try analyze_vector_table for execution "
+                "entry points instead."
+            )
+        candidates: list[tuple[int, int, str]] = []
+        infrastructure: list[tuple[int, int, str]] = []
+        for sym in symtab.iter_symbols():
+            if sym["st_info"]["type"] != "STT_FUNC":
+                continue
+            name = sym.name or ""
+            if not name:
+                continue
+            addr = sym["st_value"] & ~1
+            size = sym["st_size"]
+            if any(name.startswith(p) for p in _FREERTOS_INFRA_PREFIX):
+                infrastructure.append((addr, size, name))
+            elif any(h in name for h in _TASK_NAME_HINTS):
+                candidates.append((addr, size, name))
+
+        lines = [f"Likely task entry-point functions ({len(candidates)}):"]
+        if not candidates:
+            lines.append("  (no matches; binary may use non-standard naming)")
+        for addr, size, name in sorted(candidates)[:80]:
+            lines.append(f"  0x{addr:08x}  size={size:>5}  {name}")
+        lines.append("")
+        lines.append(
+            f"FreeRTOS / kernel infrastructure functions "
+            f"({len(infrastructure)}):"
+        )
+        for addr, size, name in sorted(infrastructure)[:60]:
+            lines.append(f"  0x{addr:08x}  size={size:>5}  {name}")
+        return "\n".join(lines)
+    finally:
+        fh.close()
+
+
+# ---------------------------------------------------------------------------
+# analyze_vector_table
+# ---------------------------------------------------------------------------
+
+
+# ARM Cortex-M built-in exceptions (index 0 is the initial SP, not a handler).
+_CORTEX_M_CORE = [
+    "Initial_SP", "Reset", "NMI", "HardFault",
+    "MemManage", "BusFault", "UsageFault", "Reserved",
+    "Reserved", "Reserved", "Reserved", "SVCall",
+    "DebugMon", "Reserved", "PendSV", "SysTick",
+]
+
+
+async def _handle_analyze_vector_table(input: dict, context: ToolContext) -> str:
+    path = _storage_path(context)
+    if path is None:
+        return "Error: firmware blob is unavailable."
+    count = max(16, min(int(input.get("count", 32) or 32), 256))
+
+    elf, fh = _open_elf(path)
+    blob: bytes | None = None
+    section_name = ""
+    base_addr = 0
+    base_known = False
+    sym_at: dict[int, str] = {}
+    try:
+        if elf is not None:
+            for cand in (".isr_vector", ".vectors", ".vector_table"):
+                sec = elf.get_section_by_name(cand)
+                if sec is not None:
+                    blob = sec.data()
+                    section_name = cand
+                    base_addr = sec["sh_addr"]
+                    base_known = True
+                    break
+            if blob is None:
+                # Fall back to the first executable LOAD segment — in most
+                # Cortex-M firmware the vector table sits at the start of
+                # flash, which is the first LOAD segment.
+                for seg in elf.iter_segments():
+                    if seg["p_type"] == "PT_LOAD" and seg["p_flags"] & 1:
+                        blob = bytes(seg.data())
+                        section_name = "(first executable LOAD segment)"
+                        base_addr = seg["p_vaddr"]
+                        base_known = True
+                        break
+            sym_at = _build_symtab(elf)
+        else:
+            with open(path, "rb") as raw:
+                blob = raw.read(count * 4)
+            section_name = "(raw image, file offset 0)"
+    finally:
+        if fh is not None:
+            fh.close()
+
+    if blob is None or len(blob) < 8:
+        return "Could not locate a vector-table region in this image."
+
+    n = min(count, len(blob) // 4)
+    words = struct.unpack_from("<" + "I" * n, blob)
+
+    lines = [
+        f"Vector table source: {section_name}",
+        (
+            f"Base address: 0x{base_addr:08x}"
+            if base_known
+            else "Base address: (raw — load address unknown)"
+        ),
+        f"Entries: {n}",
+        "",
+        f"  {'#':>3}  {'addr':>10}  {'value':>10}  exception              handler",
+    ]
+    for i, w in enumerate(words):
+        if i < len(_CORTEX_M_CORE):
+            label = _CORTEX_M_CORE[i]
+        else:
+            label = f"IRQ{i - 16}"
+        # Handlers carry the thumb bit; stripping it is what hits .symtab.
+        target = w if i == 0 else (w & ~1)
+        sym = sym_at.get(target, "")
+        addr = base_addr + i * 4
+        lines.append(
+            f"  {i:>3}  0x{addr:08x}  0x{w:08x}  {label:<22} {sym}"
+        )
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# recover_base_address
+# ---------------------------------------------------------------------------
+
+
+async def _handle_recover_base_address(input: dict, context: ToolContext) -> str:
+    path = _storage_path(context)
+    if path is None:
+        return "Error: firmware blob is unavailable."
+
+    elf, fh = _open_elf(path)
+    if elf is not None:
+        try:
+            lines = [
+                f"ELF machine: {elf.header.e_machine}",
+                f"ELF entry point: 0x{elf.header.e_entry:08x}",
+                "",
+                "LOAD segments:",
+            ]
+            any_seg = False
+            for seg in elf.iter_segments():
+                if seg["p_type"] != "PT_LOAD":
+                    continue
+                any_seg = True
+                lines.append(
+                    f"  vaddr=0x{seg['p_vaddr']:08x}  paddr=0x{seg['p_paddr']:08x}  "
+                    f"filesz=0x{seg['p_filesz']:08x}  memsz=0x{seg['p_memsz']:08x}  "
+                    f"perms={_seg_perms(seg['p_flags'])}"
+                )
+            if not any_seg:
+                lines.append("  (none — relocatable object?)")
+            return "\n".join(lines)
+        finally:
+            fh.close()
+
+    # Raw .bin: infer from the Cortex-M reset vector
+    try:
+        with open(path, "rb") as raw:
+            head = raw.read(8)
+    except OSError as exc:
+        return f"Error reading image: {exc}"
+    if len(head) < 8:
+        return "Image too small to recover a base address."
+    initial_sp, reset_handler = struct.unpack("<II", head)
+    target = reset_handler & ~1
+    lines = [
+        "Raw binary — best-effort base recovery from Cortex-M reset vector:",
+        f"  Initial SP:    0x{initial_sp:08x}  "
+        f"(typical RAM regions: 0x20000000+, 0x10000000+)",
+        f"  Reset handler: 0x{reset_handler:08x}  "
+        f"(target 0x{target:08x}, "
+        f"thumb bit {'set' if reset_handler & 1 else 'CLEAR — suspicious!'})",
+    ]
+    if 0x08000000 <= target <= 0x080FFFFF:
+        lines.append("  Likely flash base: 0x08000000 (STM32 family)")
+    elif target < 0x00200000:
+        lines.append(
+            "  Likely flash base: 0x00000000 (generic Cortex-M alias / Nordic)"
+        )
+    elif 0x10000000 <= target <= 0x1FFFFFFF:
+        lines.append("  Likely flash base: 0x10000000 (NXP / nRF52)")
+    else:
+        lines.append(
+            "  Flash base: ambiguous — provide the load offset manually."
+        )
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# analyze_memory_map
+# ---------------------------------------------------------------------------
+
+
+# ELF section flag bits we care about
+_SHF_WRITE = 0x1
+_SHF_ALLOC = 0x2
+_SHF_EXECINSTR = 0x4
+
+
+async def _handle_analyze_memory_map(input: dict, context: ToolContext) -> str:
+    path = _storage_path(context)
+    if path is None:
+        return "Error: firmware blob is unavailable."
+    elf, fh = _open_elf(path)
+    if elf is None:
+        try:
+            size = os.path.getsize(path)
+        except OSError:
+            size = -1
+        return (
+            f"Raw binary, {size} bytes. No segment metadata available without "
+            "an ELF — call recover_base_address for a load-address estimate."
+        )
+
+    try:
+        lines = ["LOAD segments:"]
+        for seg in elf.iter_segments():
+            if seg["p_type"] != "PT_LOAD":
+                continue
+            lines.append(
+                f"  vaddr=0x{seg['p_vaddr']:08x}  paddr=0x{seg['p_paddr']:08x}  "
+                f"filesz=0x{seg['p_filesz']:08x}  memsz=0x{seg['p_memsz']:08x}  "
+                f"perms={_seg_perms(seg['p_flags'])}"
+            )
+
+        flash_rows: list[tuple[int, str]] = []
+        ram_rows: list[tuple[int, str]] = []
+        rodata_rows: list[tuple[int, str]] = []
+
+        for sec in elf.iter_sections():
+            if sec["sh_size"] == 0:
+                continue
+            name = sec.name or "(unnamed)"
+            if name.startswith(".debug") or name.startswith(".comment"):
+                continue
+            flags = sec["sh_flags"]
+            if not (flags & _SHF_ALLOC):
+                continue
+            write = bool(flags & _SHF_WRITE)
+            execinstr = bool(flags & _SHF_EXECINSTR)
+            row = (
+                f"  {name:<22} addr=0x{sec['sh_addr']:08x}  "
+                f"size=0x{sec['sh_size']:08x}  "
+                f"perms={_seg_perms((4 if flags & _SHF_ALLOC else 0) | (2 if write else 0) | (1 if execinstr else 0))}"
+            )
+            key = sec["sh_addr"]
+            if write:
+                ram_rows.append((key, row))
+            elif execinstr:
+                flash_rows.append((key, row))
+            else:
+                rodata_rows.append((key, row))
+
+        if flash_rows:
+            lines.append("")
+            lines.append("Flash (executable) sections:")
+            for _, row in sorted(flash_rows):
+                lines.append(row)
+        if rodata_rows:
+            lines.append("")
+            lines.append("Read-only data sections:")
+            for _, row in sorted(rodata_rows):
+                lines.append(row)
+        if ram_rows:
+            lines.append("")
+            lines.append("RAM (writable) sections:")
+            for _, row in sorted(ram_rows):
+                lines.append(row)
+        return "\n".join(lines)
+    finally:
+        fh.close()
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+def register_rtos_tools(registry: ToolRegistry) -> None:
+    registry.register(
+        name="detect_rtos_kernel",
+        description=(
+            "Re-run RTOS detection against the firmware blob and return the "
+            "resulting kind (linux/rtos/unknown), flavor "
+            "(freertos/zephyr/baremetal-cortexm), the matching evidence, and "
+            "ELF metadata when available. Useful for verifying the "
+            "auto-detected classification."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {},
+            "additionalProperties": False,
+        },
+        handler=_handle_detect_rtos_kernel,
+        applies_to=("rtos",),
+    )
+    registry.register(
+        name="enumerate_rtos_tasks",
+        description=(
+            "List likely RTOS task entry-point functions and FreeRTOS / "
+            "kernel infrastructure symbols by scanning the ELF .symtab. "
+            "Requires an unstripped ELF (.axf/.elf); raw .bin images are "
+            "rejected."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {},
+            "additionalProperties": False,
+        },
+        handler=_handle_enumerate_rtos_tasks,
+        applies_to=("rtos",),
+    )
+    registry.register(
+        name="analyze_vector_table",
+        description=(
+            "Parse the ARM Cortex-M vector table from the firmware. Prefers "
+            "the .isr_vector / .vectors / .vector_table section, falling back "
+            "to the first executable LOAD segment for ELFs or file offset 0 "
+            "for raw .bin. Each entry is rendered with its standard exception "
+            "name and (when known) the resolved handler symbol."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "count": {
+                    "type": "integer",
+                    "minimum": 16,
+                    "maximum": 256,
+                    "description": "Number of vector-table entries to display (default 32, max 256).",
+                },
+            },
+            "additionalProperties": False,
+        },
+        handler=_handle_analyze_vector_table,
+        applies_to=("rtos",),
+    )
+    registry.register(
+        name="recover_base_address",
+        description=(
+            "Recover the firmware load address. For ELF images returns each "
+            "LOAD segment's vaddr/paddr/perms. For raw .bin images, infers a "
+            "likely flash base from the Cortex-M reset vector (initial SP + "
+            "reset handler)."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {},
+            "additionalProperties": False,
+        },
+        handler=_handle_recover_base_address,
+        applies_to=("rtos",),
+    )
+    registry.register(
+        name="analyze_memory_map",
+        description=(
+            "Show the firmware's memory layout: ELF program-header LOAD "
+            "segments and notable allocated sections, classified into flash "
+            "(executable / read-only) vs RAM (writable). Useful for setting "
+            "up Ghidra/IDA loaders or QEMU memory maps."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {},
+            "additionalProperties": False,
+        },
+        handler=_handle_analyze_memory_map,
+        applies_to=("rtos",),
+    )

--- a/backend/app/ai/tools/security.py
+++ b/backend/app/ai/tools/security.py
@@ -835,6 +835,7 @@ def register_security_tools(registry: ToolRegistry) -> None:
             "required": ["path"],
         },
         handler=_handle_analyze_config_security,
+        applies_to=("linux",),
     )
 
     registry.register(
@@ -855,6 +856,7 @@ def register_security_tools(registry: ToolRegistry) -> None:
             "required": [],
         },
         handler=_handle_check_setuid_binaries,
+        applies_to=("linux",),
     )
 
     registry.register(
@@ -876,6 +878,7 @@ def register_security_tools(registry: ToolRegistry) -> None:
             "required": [],
         },
         handler=_handle_analyze_init_scripts,
+        applies_to=("linux",),
     )
 
     registry.register(
@@ -897,6 +900,7 @@ def register_security_tools(registry: ToolRegistry) -> None:
             "required": [],
         },
         handler=_handle_check_filesystem_permissions,
+        applies_to=("linux",),
     )
 
     registry.register(

--- a/backend/app/mcp_server.py
+++ b/backend/app/mcp_server.py
@@ -801,6 +801,8 @@ async def run_server(
                 architecture=state.architecture,
                 endianness=state.endianness,
                 extracted_path=state.extracted_path,
+                firmware_kind=state.firmware_kind,
+                rtos_flavor=state.rtos_flavor,
             )
             return GetPromptResult(
                 description="Wairz firmware analysis system prompt",

--- a/backend/app/mcp_server.py
+++ b/backend/app/mcp_server.py
@@ -269,13 +269,25 @@ def _select_firmware(
     if not firmwares:
         raise ValueError("Project has no firmware uploaded.")
 
+    # A firmware is "loadable" once unpack has produced something analysable:
+    #   - Linux: a rootfs at extracted_path
+    #   - RTOS: the original blob at storage_path (no rootfs to mount)
+    # Unknown-kind firmware needs the user to set the kind manually first.
+    def _is_loadable(fw: Firmware) -> bool:
+        if fw.extracted_path:
+            return True
+        if fw.firmware_kind == "rtos" and fw.storage_path:
+            return True
+        return False
+
     if firmware_id is not None:
         for fw in firmwares:
             if fw.id == firmware_id:
-                if not fw.extracted_path:
+                if not _is_loadable(fw):
                     raise ValueError(
-                        f"Firmware {firmware_id} has not been unpacked "
-                        f"(no extracted_path). Upload status must be 'unpacked'."
+                        f"Firmware {firmware_id} has not finished unpacking "
+                        f"or its kind is still 'unknown'. Run unpack and/or "
+                        f"set the kind on the project page first."
                     )
                 return fw
         available = ", ".join(str(fw.id) for fw in firmwares)
@@ -284,16 +296,16 @@ def _select_firmware(
             f"Available firmware IDs: {available}"
         )
 
-    unpacked = [fw for fw in firmwares if fw.extracted_path]
-    if not unpacked:
+    loadable = [fw for fw in firmwares if _is_loadable(fw)]
+    if not loadable:
         raise ValueError(
-            "No firmware in this project has been unpacked yet. "
-            "Trigger unpack via the web UI or POST /api/v1/projects/<id>/firmware/<id>/unpack "
-            "before starting the MCP server."
+            "No firmware in this project is ready for analysis. "
+            "Trigger unpack via the web UI or POST /api/v1/projects/<id>/firmware/<id>/unpack, "
+            "and confirm the kind is set if detection fell back to 'unknown'."
         )
 
-    unpacked.sort(key=lambda fw: fw.created_at)
-    return unpacked[0]
+    loadable.sort(key=lambda fw: fw.created_at)
+    return loadable[0]
 
 
 async def _load_project(

--- a/backend/app/mcp_server.py
+++ b/backend/app/mcp_server.py
@@ -84,6 +84,7 @@ class ProjectState:
     extracted_path: str = ""
     extraction_dir: str | None = None
     carved_path: str | None = None
+    storage_path: str | None = None
     firmware_loaded: bool = False
     # Firmware kind drives which MCP tools are exposed (linux/rtos/unknown).
     # When firmware isn't loaded we default to "unknown" so kind-tagged tools
@@ -350,8 +351,9 @@ async def _load_project_state(
             state.firmware_filename = firmware.original_filename or "unknown"
             state.architecture = firmware.architecture
             state.endianness = firmware.endianness
-            state.extracted_path = firmware.extracted_path
+            state.extracted_path = firmware.extracted_path or ""
             state.extraction_dir = firmware.extraction_dir
+            state.storage_path = firmware.storage_path
             # Carving-sandbox outputs live next to the original blob.
             if firmware.storage_path:
                 state.carved_path = os.path.join(
@@ -359,7 +361,11 @@ async def _load_project_state(
                 )
             else:
                 state.carved_path = None
-            state.firmware_loaded = True
+            # An RTOS firmware has no mountable rootfs but is still "loaded"
+            # for analysis purposes — its raw blob is what tools work on.
+            state.firmware_loaded = bool(
+                firmware.extracted_path or firmware.storage_path
+            )
             state.firmware_kind = firmware.firmware_kind or "unknown"
             state.rtos_flavor = firmware.rtos_flavor
         else:
@@ -370,17 +376,21 @@ async def _load_project_state(
             state.extracted_path = ""
             state.extraction_dir = None
             state.carved_path = None
+            state.storage_path = None
             state.firmware_loaded = False
             state.firmware_kind = "unknown"
             state.rtos_flavor = None
 
     # Apply path translation
     if host_storage_root and state.firmware_loaded:
-        state.extracted_path = _translate_path(state.extracted_path, host_storage_root)
+        if state.extracted_path:
+            state.extracted_path = _translate_path(state.extracted_path, host_storage_root)
         if state.extraction_dir:
             state.extraction_dir = _translate_path(state.extraction_dir, host_storage_root)
         if state.carved_path:
             state.carved_path = _translate_path(state.carved_path, host_storage_root)
+        if state.storage_path:
+            state.storage_path = _translate_path(state.storage_path, host_storage_root)
 
     return firmware_count
 
@@ -451,7 +461,10 @@ async def run_server(
                 state.firmware_id,
             )
 
-        if not os.path.isdir(state.extracted_path):
+        # RTOS/unknown firmware has no rootfs — skip the directory check and
+        # rely on storage_path instead. We still validate when extracted_path
+        # is set (Linux case).
+        if state.extracted_path and not os.path.isdir(state.extracted_path):
             logger.error(
                 "Extracted firmware path does not exist: %s",
                 state.extracted_path,
@@ -462,6 +475,12 @@ async def run_server(
                 "     docker exec -i wairz-backend-1 uv run wairz-mcp --project-id %s\n"
                 "  2. Set STORAGE_ROOT in .env to point to a local copy of the firmware data",
                 project_id,
+            )
+            sys.exit(1)
+        if not state.extracted_path and state.storage_path and not os.path.isfile(state.storage_path):
+            logger.error(
+                "Firmware storage path does not exist: %s",
+                state.storage_path,
             )
             sys.exit(1)
 
@@ -559,7 +578,18 @@ async def run_server(
         except ValueError as exc:
             return f"Error: {exc}"
 
-        if state.firmware_loaded and not os.path.isdir(state.extracted_path):
+        # Linux-style projects must have a real rootfs directory; RTOS
+        # projects expose a storage_path instead. Validate whichever one
+        # this project relies on.
+        rootfs_missing = (
+            state.extracted_path and not os.path.isdir(state.extracted_path)
+        )
+        blob_missing = (
+            not state.extracted_path
+            and state.storage_path
+            and not os.path.isfile(state.storage_path)
+        )
+        if state.firmware_loaded and (rootfs_missing or blob_missing):
             # Revert to old project + firmware
             try:
                 await _load_project_state(
@@ -571,8 +601,9 @@ async def run_server(
                 )
             except ValueError:
                 pass
+            bad_path = state.extracted_path or state.storage_path
             return (
-                f"Error: Extracted firmware path does not exist: {state.extracted_path}\n"
+                f"Error: Firmware path does not exist: {bad_path}\n"
                 f"Reverted to project '{old_name}'."
             )
 
@@ -736,6 +767,7 @@ async def run_server(
                 db=session,
                 extraction_dir=state.extraction_dir,
                 carved_path=state.carved_path,
+                storage_path=state.storage_path,
             )
             try:
                 result = await registry.execute(name, arguments, context)

--- a/backend/app/mcp_server.py
+++ b/backend/app/mcp_server.py
@@ -85,6 +85,11 @@ class ProjectState:
     extraction_dir: str | None = None
     carved_path: str | None = None
     firmware_loaded: bool = False
+    # Firmware kind drives which MCP tools are exposed (linux/rtos/unknown).
+    # When firmware isn't loaded we default to "unknown" so kind-tagged tools
+    # are filtered out — only the project-management tools remain.
+    firmware_kind: str = "unknown"
+    rtos_flavor: str | None = None
 
 
 def _resolve_storage_root() -> str | None:
@@ -355,6 +360,8 @@ async def _load_project_state(
             else:
                 state.carved_path = None
             state.firmware_loaded = True
+            state.firmware_kind = firmware.firmware_kind or "unknown"
+            state.rtos_flavor = firmware.rtos_flavor
         else:
             state.firmware_id = uuid.UUID(int=0)
             state.firmware_filename = "unknown"
@@ -364,6 +371,8 @@ async def _load_project_state(
             state.extraction_dir = None
             state.carved_path = None
             state.firmware_loaded = False
+            state.firmware_kind = "unknown"
+            state.rtos_flavor = None
 
     # Apply path translation
     if host_storage_root and state.firmware_loaded:
@@ -478,9 +487,13 @@ async def run_server(
             f"Description: {state.project_desc or '(none)'}",
         ]
         if state.firmware_loaded:
+            kind_label = state.firmware_kind
+            if state.firmware_kind == "rtos" and state.rtos_flavor:
+                kind_label = f"rtos ({state.rtos_flavor})"
             lines.extend([
                 f"Firmware: {state.firmware_filename}",
                 f"Firmware ID: {state.firmware_id}",
+                f"Kind: {kind_label}",
                 f"Architecture: {state.architecture or 'unknown'}",
                 f"Endianness: {state.endianness or 'unknown'}",
                 f"Extracted Path: {state.extracted_path}",
@@ -576,8 +589,12 @@ async def run_server(
             f"  Project ID: {state.project_id}",
         ]
         if state.firmware_loaded:
+            kind_label = state.firmware_kind
+            if state.firmware_kind == "rtos" and state.rtos_flavor:
+                kind_label = f"rtos ({state.rtos_flavor})"
             lines.extend([
                 f"  Firmware: {state.firmware_filename}",
+                f"  Kind: {kind_label}",
                 f"  Architecture: {state.architecture or 'unknown'}",
                 f"  Endianness: {state.endianness or 'unknown'}",
             ])
@@ -659,10 +676,15 @@ async def run_server(
     server = Server("wairz")
 
     # --- Tool listing ---
+    # Filter dynamically on each call so switch_project (which mutates state
+    # in place) immediately changes the visible tool surface.
     @server.list_tools()
     async def list_tools() -> list[Tool]:
+        kind = state.firmware_kind
         tools = []
         for tool_def in registry._tools.values():
+            if kind not in tool_def.applies_to:
+                continue
             tools.append(
                 Tool(
                     name=tool_def.name,
@@ -691,6 +713,19 @@ async def run_server(
                     "Upload and unpack firmware via the Wairz web UI before "
                     "using analysis tools. You can also use switch_project to "
                     "change to a project that has firmware available."
+                ),
+            )]
+        # Defense in depth: even if the client has a stale tool list, refuse
+        # to run tools that don't apply to this firmware's kind.
+        tool_def = registry._tools.get(name)
+        if tool_def is not None and state.firmware_kind not in tool_def.applies_to:
+            return [TextContent(
+                type="text",
+                text=(
+                    f"Error: Tool '{name}' does not apply to this project "
+                    f"(firmware_kind='{state.firmware_kind}', "
+                    f"tool applies to: {', '.join(tool_def.applies_to)}). "
+                    f"Change the firmware kind in the Wairz UI if this is wrong."
                 ),
             )]
         async with session_factory() as session:
@@ -725,12 +760,16 @@ async def run_server(
     @server.read_resource()
     async def read_resource(uri) -> str:
         if str(uri) == "wairz://project/info":
+            kind_label = state.firmware_kind
+            if state.firmware_kind == "rtos" and state.rtos_flavor:
+                kind_label = f"rtos ({state.rtos_flavor})"
             lines = [
                 f"Project: {state.project_name}",
                 f"Description: {state.project_desc}",
                 f"Project ID: {state.project_id}",
                 f"Firmware: {state.firmware_filename}",
                 f"Firmware ID: {state.firmware_id}",
+                f"Kind: {kind_label}",
                 f"Architecture: {state.architecture or 'unknown'}",
                 f"Endianness: {state.endianness or 'unknown'}",
                 f"Extracted Path: {state.extracted_path}",

--- a/backend/app/mcp_server.py
+++ b/backend/app/mcp_server.py
@@ -26,7 +26,7 @@ from dataclasses import dataclass, field
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
-from mcp.server import Server
+from mcp.server import NotificationOptions, Server
 from mcp.server.stdio import stdio_server
 from mcp.types import (
     GetPromptResult,
@@ -578,6 +578,7 @@ async def run_server(
         old_name = state.project_name
         old_id = state.project_id
         old_firmware_id = state.firmware_id if state.firmware_loaded else None
+        old_kind = state.firmware_kind
 
         try:
             await _load_project_state(
@@ -626,6 +627,16 @@ async def run_server(
             state.project_name,
             state.project_id,
         )
+
+        # If the firmware kind changed, the visible tool set changes too —
+        # tell the client to re-fetch list_tools so kind-tagged tools come
+        # and go without requiring an MCP reconnect.
+        if state.firmware_kind != old_kind:
+            try:
+                await server.request_context.session.send_tool_list_changed()
+            except Exception:
+                # Notification is best-effort; never fail switch_project on it.
+                logger.exception("send_tool_list_changed failed")
 
         lines = [
             f"Switched to project '{state.project_name}'.",
@@ -861,12 +872,19 @@ async def run_server(
 
     # --- Run ---
     logger.info("Starting Wairz MCP server (stdio transport)...")
+    # Advertise list-changed support in the server capabilities so clients
+    # subscribe to notifications/tools/list_changed (emitted from
+    # switch_project when the active firmware kind changes the visible
+    # tool set).
+    init_options = server.create_initialization_options(
+        notification_options=NotificationOptions(
+            tools_changed=True,
+            resources_changed=True,
+            prompts_changed=True,
+        ),
+    )
     async with stdio_server() as (read_stream, write_stream):
-        await server.run(
-            read_stream,
-            write_stream,
-            server.create_initialization_options(),
-        )
+        await server.run(read_stream, write_stream, init_options)
 
 
 def main() -> None:

--- a/backend/app/models/firmware.py
+++ b/backend/app/models/firmware.py
@@ -30,6 +30,11 @@ class Firmware(Base):
     os_info: Mapped[str | None] = mapped_column(Text)
     kernel_path: Mapped[str | None] = mapped_column(String(512))
     version_label: Mapped[str | None] = mapped_column(String(100))
+    firmware_kind: Mapped[str] = mapped_column(
+        String(20), nullable=False, default="unknown", server_default="unknown"
+    )
+    firmware_kind_source: Mapped[str | None] = mapped_column(String(20))
+    rtos_flavor: Mapped[str | None] = mapped_column(String(40))
     unpack_log: Mapped[str | None] = mapped_column(Text)
     created_at: Mapped[datetime] = mapped_column(server_default=func.now())
 

--- a/backend/app/routers/firmware.py
+++ b/backend/app/routers/firmware.py
@@ -12,6 +12,7 @@ from app.models.firmware import Firmware
 from app.models.project import Project
 from app.schemas.firmware import (
     FirmwareDetailResponse,
+    FirmwareKindUpdate,
     FirmwareMetadataResponse,
     FirmwareUpdate,
     FirmwareUploadResponse,
@@ -78,6 +79,29 @@ async def update_firmware(
     update_data = data.model_dump(exclude_unset=True)
     for key, value in update_data.items():
         setattr(firmware, key, value)
+    await service.db.flush()
+    return firmware
+
+
+@router.patch("/{firmware_id}/kind", response_model=FirmwareDetailResponse)
+async def update_firmware_kind(
+    project_id: uuid.UUID,
+    firmware_id: uuid.UUID,
+    data: FirmwareKindUpdate,
+    service: FirmwareService = Depends(get_firmware_service),
+):
+    """Manually override the detected firmware kind (Linux vs RTOS).
+
+    Sets firmware_kind_source='manual' so detection re-runs won't clobber
+    the user's choice.
+    """
+    firmware = await service.get_by_id(firmware_id)
+    if not firmware or firmware.project_id != project_id:
+        raise HTTPException(404, "Firmware not found")
+
+    firmware.firmware_kind = data.kind
+    firmware.rtos_flavor = data.rtos_flavor if data.kind == "rtos" else None
+    firmware.firmware_kind_source = "manual"
     await service.db.flush()
     return firmware
 

--- a/backend/app/routers/firmware.py
+++ b/backend/app/routers/firmware.py
@@ -192,6 +192,15 @@ async def _run_unpack_background(
                     firmware.unpack_log = result.unpack_log
                     project.status = "error"
 
+                # Persist auto-detected kind regardless of unpack success
+                # — even an "error" image is useful info for the user.
+                # Manual overrides win: if the user already pinned the
+                # kind via the dropdown, leave their choice alone.
+                if firmware.firmware_kind_source != "manual":
+                    firmware.firmware_kind = result.firmware_kind
+                    firmware.rtos_flavor = result.rtos_flavor
+                    firmware.firmware_kind_source = "detected"
+
                 await db.commit()
             except Exception:
                 await db.rollback()

--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -72,8 +72,32 @@ async def create_project(data: ProjectCreate, db: AsyncSession = Depends(get_db)
 
 @router.get("", response_model=list[ProjectListResponse])
 async def list_projects(db: AsyncSession = Depends(get_db)):
-    result = await db.execute(select(Project).order_by(Project.created_at.desc()))
-    return result.scalars().all()
+    # Eager-load firmware so we can surface the active firmware's kind
+    # without making the sidebar fetch each project's detail separately.
+    result = await db.execute(
+        select(Project)
+        .options(selectinload(Project.firmware))
+        .order_by(Project.created_at.desc())
+    )
+    projects = result.scalars().all()
+    out = []
+    for p in projects:
+        # Use the most recently uploaded firmware as the "active" one —
+        # matches the MCP server's default-firmware selection.
+        active_fw = max(p.firmware, key=lambda f: f.created_at) if p.firmware else None
+        out.append(
+            ProjectListResponse(
+                id=p.id,
+                name=p.name,
+                description=p.description,
+                status=p.status,
+                created_at=p.created_at,
+                updated_at=p.updated_at,
+                firmware_kind=active_fw.firmware_kind if active_fw else None,
+                rtos_flavor=active_fw.rtos_flavor if active_fw else None,
+            )
+        )
+    return out
 
 
 @router.get("/{project_id}", response_model=ProjectResponse)

--- a/backend/app/schemas/firmware.py
+++ b/backend/app/schemas/firmware.py
@@ -1,7 +1,13 @@
 import uuid
 from datetime import datetime
+from typing import Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, model_validator
+
+
+FirmwareKind = Literal["linux", "rtos", "unknown"]
+FirmwareKindSource = Literal["detected", "manual"]
+RtosFlavor = Literal["freertos", "zephyr", "baremetal-cortexm"]
 
 
 class FirmwareUploadResponse(BaseModel):
@@ -12,11 +18,25 @@ class FirmwareUploadResponse(BaseModel):
     sha256: str
     file_size: int | None
     version_label: str | None = None
+    firmware_kind: FirmwareKind = "unknown"
+    firmware_kind_source: FirmwareKindSource | None = None
+    rtos_flavor: RtosFlavor | None = None
     created_at: datetime
 
 
 class FirmwareUpdate(BaseModel):
     version_label: str | None = None
+
+
+class FirmwareKindUpdate(BaseModel):
+    kind: FirmwareKind
+    rtos_flavor: RtosFlavor | None = None
+
+    @model_validator(mode="after")
+    def _flavor_only_for_rtos(self) -> "FirmwareKindUpdate":
+        if self.kind != "rtos" and self.rtos_flavor is not None:
+            raise ValueError("rtos_flavor may only be set when kind == 'rtos'")
+        return self
 
 
 class FirmwareDetailResponse(BaseModel):
@@ -35,6 +55,9 @@ class FirmwareDetailResponse(BaseModel):
     os_info: str | None
     kernel_path: str | None
     version_label: str | None = None
+    firmware_kind: FirmwareKind = "unknown"
+    firmware_kind_source: FirmwareKindSource | None = None
+    rtos_flavor: RtosFlavor | None = None
     unpack_log: str | None
     created_at: datetime
 

--- a/backend/app/schemas/project.py
+++ b/backend/app/schemas/project.py
@@ -1,5 +1,6 @@
 import uuid
 from datetime import datetime
+from typing import Literal
 
 from pydantic import BaseModel
 
@@ -25,6 +26,9 @@ class FirmwareResponse(BaseModel):
     endianness: str | None
     os_info: str | None
     version_label: str | None = None
+    firmware_kind: Literal["linux", "rtos", "unknown"] = "unknown"
+    firmware_kind_source: Literal["detected", "manual"] | None = None
+    rtos_flavor: Literal["freertos", "zephyr", "baremetal-cortexm"] | None = None
     created_at: datetime
 
 

--- a/backend/app/schemas/project.py
+++ b/backend/app/schemas/project.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import datetime
 from typing import Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, model_validator
 
 
 class ProjectCreate(BaseModel):
@@ -42,6 +42,20 @@ class ProjectResponse(BaseModel):
     created_at: datetime
     updated_at: datetime
     firmware: list[FirmwareResponse] = []
+    # Mirrors ProjectListResponse so that the frontend Project type stays
+    # consistent across list / detail / create / update flows.
+    firmware_kind: Literal["linux", "rtos", "unknown"] | None = None
+    rtos_flavor: Literal["freertos", "zephyr", "baremetal-cortexm"] | None = None
+
+    @model_validator(mode="after")
+    def _populate_kind_from_firmware(self) -> "ProjectResponse":
+        # Derive the project-level kind/flavor from the most recently
+        # uploaded firmware so callers don't have to dig into the list.
+        if self.firmware_kind is None and self.firmware:
+            active = max(self.firmware, key=lambda f: f.created_at)
+            self.firmware_kind = active.firmware_kind
+            self.rtos_flavor = active.rtos_flavor
+        return self
 
 
 class ProjectListResponse(BaseModel):

--- a/backend/app/schemas/project.py
+++ b/backend/app/schemas/project.py
@@ -53,3 +53,8 @@ class ProjectListResponse(BaseModel):
     status: str
     created_at: datetime
     updated_at: datetime
+    # Surface the active firmware's kind so the sidebar can filter analysis
+    # tabs without fetching each project's full detail. Null when no
+    # firmware has been uploaded for the project yet.
+    firmware_kind: Literal["linux", "rtos", "unknown"] | None = None
+    rtos_flavor: Literal["freertos", "zephyr", "baremetal-cortexm"] | None = None

--- a/backend/app/services/file_service.py
+++ b/backend/app/services/file_service.py
@@ -127,12 +127,17 @@ class FileService:
 
     ROOTFS_VNAME = "rootfs"
     CARVED_VNAME = "_carved"
+    # Virtual entry that exposes the original firmware blob to analysis
+    # tools. For Linux projects this is alongside /rootfs/...; for RTOS
+    # projects (no rootfs) it's the only entry below /.
+    FIRMWARE_VNAME = "firmware"
 
     def __init__(
         self,
         extracted_root: str,
         extraction_dir: str | None = None,
         carved_path: str | None = None,
+        firmware_path: str | None = None,
     ):
         self.extracted_root = extracted_root
         # Only enable virtual top-level when extraction_dir differs from rootfs
@@ -144,6 +149,18 @@ class FileService:
         # exists, files written by the carving sandbox become visible to
         # all read tools at /_carved/...
         self.carved_path = carved_path if carved_path else None
+        # Original firmware blob path (e.g. an .axf for an RTOS project).
+        # Surfaced as /firmware/<basename> so binary tools (extract_strings,
+        # get_binary_info, decompile_function, ...) can analyse it through
+        # the same virtual filesystem the rest of Wairz uses.
+        self.firmware_path = firmware_path if firmware_path else None
+        self.firmware_basename = (
+            os.path.basename(firmware_path) if firmware_path else None
+        )
+        # When there is no rootfs (RTOS / unknown), the firmware blob is
+        # the only thing analysis tools can see — switch the virtual
+        # filesystem into single-file mode.
+        self.is_blob_only = bool(firmware_path) and not extracted_root
         # Lazily built mapping from virtual name → real path for nested roots
         self._virtual_map: dict[str, str] | None = None
 
@@ -202,6 +219,42 @@ class FileService:
         """Map a virtual path to a real filesystem path and validate it."""
         clean = path.strip("/")
 
+        # /firmware[/<basename>] — surfaces the original firmware blob.
+        # Only the configured basename resolves; anything else under
+        # /firmware/ raises because there is no real directory tree.
+        if self.firmware_path and (
+            clean == self.FIRMWARE_VNAME
+            or clean.startswith(self.FIRMWARE_VNAME + "/")
+        ):
+            sub = clean[len(self.FIRMWARE_VNAME):].lstrip("/")
+            if not sub:
+                # /firmware → the parent directory used as a sandbox root
+                return os.path.realpath(os.path.dirname(self.firmware_path))
+            if sub == self.firmware_basename:
+                return os.path.realpath(self.firmware_path)
+            from app.utils.sandbox import PathTraversalError
+            raise PathTraversalError(
+                f"Path traversal detected: only /{self.FIRMWARE_VNAME}/"
+                f"{self.firmware_basename} is exposed for this project"
+            )
+
+        # Blob-only mode (RTOS without a rootfs): be forgiving about how
+        # callers spell the firmware path. "/", "" and the bare basename
+        # all resolve to the firmware blob — same effect as
+        # /firmware/<basename> above.
+        if self.is_blob_only:
+            assert self.firmware_path is not None
+            if not clean:
+                return os.path.realpath(os.path.dirname(self.firmware_path))
+            if clean == self.firmware_basename:
+                return os.path.realpath(self.firmware_path)
+            from app.utils.sandbox import PathTraversalError
+            raise PathTraversalError(
+                f"Path traversal detected: this project has no rootfs — "
+                f"use /{self.FIRMWARE_VNAME}/{self.firmware_basename} or "
+                f"/{self.firmware_basename}"
+            )
+
         # Carving sandbox outputs live outside the extraction tree but are
         # surfaced at /_carved/... so the agent's carved files are visible
         # to read_file, extract_strings, decompile_function, etc.
@@ -247,6 +300,7 @@ class FileService:
 
         Returns:
             ``/rootfs/...`` when ``abs_path`` is inside the rootfs.
+            ``/firmware/<basename>`` when ``abs_path`` is the firmware blob.
             ``/<vname>/...`` when inside a virtual partition entry.
             ``/<rel>`` when at the top level of ``extraction_dir`` (sibling files).
             ``None`` when ``abs_path`` is outside every sandboxed root.
@@ -255,6 +309,12 @@ class FileService:
             real = os.path.realpath(abs_path)
         except OSError:
             return None
+
+        # Firmware blob (RTOS or Linux when storage_path is wired through)
+        if self.firmware_path:
+            firmware_real = os.path.realpath(self.firmware_path)
+            if real == firmware_real:
+                return f"/{self.FIRMWARE_VNAME}/{self.firmware_basename}"
 
         # Carved outputs map to /_carved/...; check before rootfs because the
         # carved dir lives next to (not inside) the extraction tree.
@@ -436,8 +496,27 @@ class FileService:
 
     def list_directory(self, path: str = "/") -> tuple[list[FileEntry], bool]:
         """List directory contents. Returns (entries, truncated)."""
+        clean = path.strip("/")
+
+        # Blob-only mode: there's no real directory tree to walk, just
+        # the firmware file at /firmware/<basename>. Show it at the root
+        # and at /firmware so listing tools surface something useful.
+        if self.is_blob_only and clean in ("", self.FIRMWARE_VNAME):
+            assert self.firmware_path is not None
+            try:
+                st = os.lstat(self.firmware_path)
+                entry = FileEntry(
+                    name=self.firmware_basename or "firmware",
+                    type="file",
+                    size=st.st_size,
+                    permissions=_format_permissions(st.st_mode),
+                )
+                return [entry], False
+            except OSError:
+                return [], False
+
         # Virtual top-level when extraction_dir is set
-        if self.extraction_dir and path.strip("/") == "":
+        if self.extraction_dir and clean == "":
             return self._list_virtual_root()
 
         full_path = self._resolve(path)

--- a/backend/app/services/rtos_detection_service.py
+++ b/backend/app/services/rtos_detection_service.py
@@ -1,0 +1,267 @@
+"""RTOS firmware-kind detection.
+
+Single-pass classifier invoked at the tail of the unpack pipeline. The
+strongest signal is the existence of a Linux filesystem root — if
+``find_filesystem_root`` succeeded, we are looking at Linux. Otherwise we
+scan the raw firmware image and any extracted ELF/blob siblings for
+known RTOS signatures and return ``(kind, flavor)``.
+
+We are deliberately conservative: only the v1-supported flavors
+(``freertos``, ``zephyr``, ``baremetal-cortexm``) ever get reported. An
+ambiguous or unrecognised image returns ``("unknown", None)`` so the user
+can override via the kind dropdown.
+"""
+
+from __future__ import annotations
+
+import os
+import struct
+from dataclasses import dataclass
+
+from elftools.elf.elffile import ELFFile
+
+
+# String markers — byte literals so we can scan raw binaries without
+# decoding. Each tuple is (marker, weight). We require either one
+# weight>=2 hit or two weight==1 hits to call a flavor.
+_FREERTOS_MARKERS: tuple[tuple[bytes, int], ...] = (
+    (b"xTaskCreate", 2),
+    (b"pxCurrentTCB", 2),
+    (b"vTaskStartScheduler", 2),
+    (b"FreeRTOS", 1),
+    (b"vTaskDelay", 1),
+    (b"prvIdleTask", 1),
+    (b"xQueueGenericSend", 1),
+)
+
+_ZEPHYR_MARKERS: tuple[tuple[bytes, int], ...] = (
+    (b"Booting Zephyr OS", 3),
+    (b"ZEPHYR_BASE", 2),
+    (b"z_thread_", 1),
+    (b"k_thread_create", 1),
+    (b"_ZEPHYR_", 1),
+    (b"sys_clock_announce", 1),
+)
+
+# Heuristics for baremetal Cortex-M: we look for ARM ELFs *without* any
+# of the above RTOS markers and with a vector-table-like layout.
+_FLAVOR_THRESHOLD = 2  # cumulative weight needed to call a match
+
+# How much of each candidate file to scan. Most RTOS images are small
+# (< 4 MB); cap at 16 MB so a misclassified Linux blob doesn't blow
+# memory if it gets here.
+_SCAN_BUDGET_BYTES = 16 * 1024 * 1024
+
+
+@dataclass
+class KindDetection:
+    kind: str  # "linux" | "rtos" | "unknown"
+    flavor: str | None
+    notes: str
+
+
+def _score_markers(
+    blob: bytes, markers: tuple[tuple[bytes, int], ...]
+) -> int:
+    """Sum weights of every marker present in *blob*."""
+    return sum(weight for marker, weight in markers if marker in blob)
+
+
+def _read_capped(path: str, cap: int = _SCAN_BUDGET_BYTES) -> bytes:
+    try:
+        with open(path, "rb") as f:
+            return f.read(cap)
+    except OSError:
+        return b""
+
+
+def _candidate_files(
+    firmware_path: str, extraction_dir: str | None
+) -> list[str]:
+    """Files worth scanning for RTOS signatures.
+
+    Always include the original firmware image. If we have an extraction
+    directory, also include any ELFs and any large flat binaries siblings
+    found in it (those are usually the kernel/firmware blob binwalk
+    surfaced from a wrapping container format).
+    """
+    seen: set[str] = set()
+    out: list[str] = []
+
+    def _add(p: str) -> None:
+        rp = os.path.realpath(p)
+        if rp in seen:
+            return
+        seen.add(rp)
+        out.append(p)
+
+    if os.path.isfile(firmware_path):
+        _add(firmware_path)
+
+    if not extraction_dir or not os.path.isdir(extraction_dir):
+        return out
+
+    # Walk the extraction tree, collecting ELFs and big flat blobs. Cap
+    # at ~30 candidates so degenerate trees don't make us scan forever.
+    max_candidates = 30
+    for root, _dirs, files in os.walk(extraction_dir):
+        for name in files:
+            if len(out) >= max_candidates:
+                return out
+            full = os.path.join(root, name)
+            try:
+                size = os.path.getsize(full)
+            except OSError:
+                continue
+            # Skip tiny files; signatures don't fit
+            if size < 1024:
+                continue
+            ext = os.path.splitext(name)[1].lower()
+            # Skip JSON/log sidecars binwalk leaves around
+            if ext in {".json", ".txt", ".log"}:
+                continue
+            _add(full)
+
+    return out
+
+
+def _detect_freertos_or_zephyr(
+    candidates: list[str],
+) -> tuple[str | None, str]:
+    """Return ``(flavor, notes)`` if any candidate matches FreeRTOS/Zephyr."""
+    best: tuple[int, str | None, str] = (0, None, "")  # (score, flavor, source path)
+
+    for path in candidates:
+        blob = _read_capped(path)
+        if not blob:
+            continue
+        for flavor, markers in (
+            ("freertos", _FREERTOS_MARKERS),
+            ("zephyr", _ZEPHYR_MARKERS),
+        ):
+            score = _score_markers(blob, markers)
+            if score >= _FLAVOR_THRESHOLD and score > best[0]:
+                best = (score, flavor, path)
+
+    if best[1] is None:
+        return None, ""
+    return best[1], f"matched {best[1]} markers (score={best[0]}) in {os.path.basename(best[2])}"
+
+
+def _looks_like_cortex_m_elf(path: str) -> bool:
+    """Whether *path* is an ARM ELF that walks like baremetal Cortex-M.
+
+    Heuristic: ARM ELF (e_machine == EM_ARM) with ARM v6-M / v7-M / v8-M
+    architecture tag, OR a section called ``.isr_vector`` / a symbol
+    ``Reset_Handler``. We can't reliably read attributes from every
+    toolchain output so we look at multiple weak signals.
+    """
+    try:
+        with open(path, "rb") as f:
+            magic = f.read(4)
+            if magic != b"\x7fELF":
+                return False
+            f.seek(0)
+            elf = ELFFile(f)
+            if elf.header.e_machine != "EM_ARM":
+                return False
+
+            # .isr_vector is the canonical Cortex-M vector-table section
+            # name across CMSIS and Zephyr/STM32/NXP startup files.
+            for section in elf.iter_sections():
+                name = section.name or ""
+                if name in (".isr_vector", ".vectors", ".vector_table"):
+                    return True
+
+            # Symbol fallback — Reset_Handler is the ARM-Cortex-M ABI
+            # convention; ARM A-profile uses _start instead.
+            symtab = elf.get_section_by_name(".symtab")
+            if symtab is not None:
+                for sym in symtab.iter_symbols():
+                    if sym.name in ("Reset_Handler", "g_pfnVectors"):
+                        return True
+    except Exception:
+        return False
+    return False
+
+
+def _looks_like_cortex_m_raw(path: str) -> bool:
+    """Heuristic vector-table check on a raw (non-ELF) firmware blob.
+
+    Cortex-M reset state: word 0 = initial SP (must point into RAM),
+    word 1 = Reset_Handler address (must be in flash with the Thumb bit
+    set, i.e. odd). We sample a handful of vendor RAM/flash splits — the
+    common ones, not exhaustively.
+    """
+    try:
+        with open(path, "rb") as f:
+            head = f.read(8)
+            if len(head) < 8:
+                return False
+    except OSError:
+        return False
+
+    initial_sp, reset_handler = struct.unpack("<II", head)
+
+    # Reset handler must have the Thumb bit set on Cortex-M
+    if reset_handler & 1 == 0:
+        return False
+
+    # Initial SP commonly lives in 0x20000000 (SRAM) or 0x10000000.
+    # Reset handler commonly lives in 0x00000000 (alias), 0x08000000
+    # (STM32 flash), 0x00100000 (NXP), 0x00010000 (TI). We accept these
+    # ranges as evidence; one false positive is cheaper than a miss
+    # because the user can override.
+    sp_ok = (
+        0x20000000 <= initial_sp <= 0x2FFFFFFF
+        or 0x10000000 <= initial_sp <= 0x1FFFFFFF
+    )
+    reset_target = reset_handler & ~1
+    rh_ok = (
+        reset_target < 0x00200000  # generic flash low region
+        or 0x08000000 <= reset_target <= 0x08FFFFFF  # STM32
+        or 0x10000000 <= reset_target <= 0x1FFFFFFF  # NXP / Nordic
+    )
+    return sp_ok and rh_ok
+
+
+def _detect_baremetal_cortex_m(candidates: list[str]) -> tuple[bool, str]:
+    """Check whether any candidate looks like baremetal Cortex-M."""
+    for path in candidates:
+        if _looks_like_cortex_m_elf(path):
+            return True, f"Cortex-M ELF layout in {os.path.basename(path)}"
+        if _looks_like_cortex_m_raw(path):
+            return True, f"Cortex-M reset vector in {os.path.basename(path)}"
+    return False, ""
+
+
+def detect_firmware_kind(
+    firmware_path: str,
+    extraction_dir: str | None,
+    fs_root: str | None,
+) -> KindDetection:
+    """Classify a firmware image as Linux, RTOS, or unknown.
+
+    *fs_root* should be the result of ``find_filesystem_root``. When it
+    is non-None we trust it and short-circuit to ``linux``.
+    """
+    if fs_root is not None:
+        return KindDetection(kind="linux", flavor=None, notes="filesystem root located")
+
+    candidates = _candidate_files(firmware_path, extraction_dir)
+    if not candidates:
+        return KindDetection(kind="unknown", flavor=None, notes="no candidate files to scan")
+
+    flavor, notes = _detect_freertos_or_zephyr(candidates)
+    if flavor is not None:
+        return KindDetection(kind="rtos", flavor=flavor, notes=notes)
+
+    is_cm, cm_notes = _detect_baremetal_cortex_m(candidates)
+    if is_cm:
+        return KindDetection(kind="rtos", flavor="baremetal-cortexm", notes=cm_notes)
+
+    return KindDetection(
+        kind="unknown",
+        flavor=None,
+        notes="no Linux rootfs and no recognised RTOS signatures",
+    )

--- a/backend/app/workers/unpack.py
+++ b/backend/app/workers/unpack.py
@@ -14,6 +14,8 @@ class UnpackResult:
     endianness: str | None = None
     os_info: str | None = None
     kernel_path: str | None = None
+    firmware_kind: str = "unknown"
+    rtos_flavor: str | None = None
     unpack_log: str = ""
     success: bool = False
     error: str | None = None
@@ -476,11 +478,30 @@ async def unpack_firmware(firmware_path: str, output_base_dir: str) -> UnpackRes
     )
     result.unpack_log = (result.unpack_log or "") + "\n" + dispatcher_log
 
-    # Step 2: Find the filesystem root
+    # Step 2: Find the filesystem root (Linux signal)
     fs_root = find_filesystem_root(extraction_dir)
+
+    # Step 2a: Classify the firmware kind. If we found a rootfs, the
+    # detector trusts that; otherwise it scans the raw image and any
+    # extracted blobs for RTOS signatures.
+    from app.services.rtos_detection_service import detect_firmware_kind
+
+    detection = detect_firmware_kind(firmware_path, extraction_dir, fs_root)
+    result.firmware_kind = detection.kind
+    result.rtos_flavor = detection.flavor
+    result.unpack_log = (result.unpack_log or "") + f"\nkind detection: {detection.notes}"
+
     if not fs_root:
-        result.error = "Could not locate filesystem root in extracted contents"
+        # Non-Linux path: only succeed if we positively recognised an
+        # RTOS. An unknown image has no rootfs to mount and no RTOS
+        # workflow to run, so keep the error behaviour the frontend
+        # already handles (offer to upload-rootfs).
+        if detection.kind == "rtos":
+            result.success = True
+        else:
+            result.error = "Could not locate filesystem root in extracted contents"
         return result
+
     result.extracted_path = fs_root
 
     # Step 2b: Determine the binwalk output directory (parent of rootfs).

--- a/docs/features/rtos.md
+++ b/docs/features/rtos.md
@@ -1,0 +1,65 @@
+# RTOS Support
+
+Wairz supports four firmware kinds end-to-end: **Linux**, **FreeRTOS**, **Zephyr**, and **baremetal Cortex-M**. Auto-detection runs when you upload and unpack a firmware image; you can override the result manually if it lands on the wrong category.
+
+The kind discriminator drives:
+
+- Which MCP tools are exposed to the AI (Linux-only tools are hidden on RTOS projects, RTOS-only tools are hidden on Linux projects).
+- Which sub-pages appear in the project sidebar.
+- The system prompt the MCP server gives to Claude — RTOS sessions get a knowledge block on FreeRTOS task models, Zephyr kernel symbols, and Cortex-M conventions, instead of the Linux QEMU / init-script / SBOM blocks.
+
+## Auto-detection
+
+When you upload + unpack firmware, Wairz first attempts standard Linux extraction (binwalk + custom dispatcher). If a Linux filesystem root is located, the kind is set to `linux`. If not, the RTOS detection service runs:
+
+| Kind | Flavor | What it looks for |
+|------|--------|-------------------|
+| `rtos` | `freertos` | Byte-marker scan for `xTaskCreate`, `pxCurrentTCB`, `vTaskStartScheduler`, `prvIdleTask`, `vTaskDelay`, `xQueueGenericSend` (weighted score ≥ 2) |
+| `rtos` | `zephyr` | `Booting Zephyr OS`, `ZEPHYR_BASE`, `z_thread_*`, `k_thread_create` markers |
+| `rtos` | `baremetal-cortexm` | ARM ELF with a `.isr_vector` / `.vectors` / `.vector_table` section, OR a raw blob whose first 8 bytes are a Cortex-M reset vector (initial SP in SRAM, reset handler in flash with the thumb bit set) |
+| `unknown` | — | No Linux rootfs and no recognised RTOS signature |
+
+Detection results are written to the firmware row with `firmware_kind_source = 'detected'`. Re-unpacking the same firmware re-runs detection.
+
+## Manual override
+
+The kind dropdown on the project page (next to each firmware card) lets you pin the kind. Setting it manually flips `firmware_kind_source` to `'manual'`, and re-detection on subsequent unpacks will not overwrite your choice.
+
+Override is the right move when:
+
+- A vendor OTA wrapper hides the inner firmware blob and detection misses the markers
+- The firmware is heavily stripped and standard symbols don't match
+- You want to test the analysis flow for a different kind on a known-Linux image
+
+## RTOS analysis tools
+
+When `firmware_kind == "rtos"` is active, Claude gets a dedicated tool category:
+
+- **`detect_rtos_kernel`** — re-runs detection and reports kind / flavor / evidence + ELF metadata
+- **`enumerate_rtos_tasks`** — scans the `.symtab` for likely task entry-point functions and FreeRTOS / kernel infrastructure symbols
+- **`analyze_vector_table`** — parses the Cortex-M vector table with handler-symbol resolution
+- **`recover_base_address`** — returns LOAD-segment vaddr/paddr for ELFs, or infers a flash base from the reset vector for raw `.bin`
+- **`analyze_memory_map`** — classifies allocated sections into flash (executable / read-only) vs RAM (writable)
+
+These take their input from the firmware blob directly, exposed via `/firmware/<basename>` in the virtual filesystem.
+
+## What's hidden on RTOS projects
+
+The following Linux-specific MCP tools are tagged `applies_to=("linux",)` and hidden when an RTOS project is active:
+
+- All emulation tools (15 — QEMU is Linux-userland-mode-only at present)
+- `analyze_config_security`, `check_setuid_binaries`, `analyze_init_scripts`, `check_filesystem_permissions` (rootfs-walking security tools)
+- `get_component_map` (component-graph generator, requires shared-library DAG)
+
+The corresponding sidebar pages (Component Map, SBOM, Emulation, Fuzzing, Compare) are also hidden on RTOS projects.
+
+## Project Files explorer for RTOS projects
+
+RTOS projects have no rootfs to walk, but they still have `WAIRZ.md`, `SCRATCHPAD.md`, and any documents you upload. The sidebar exposes a **Project Files** tab on every project — for Linux it's the full firmware-tree explorer (relabelled "File Explorer"); for RTOS / unknown it shows only the documents pane, with the same Monaco-based inline editor.
+
+## Limitations
+
+- **No RTOS emulation yet.** Static analysis works; dynamic boot in QEMU's Cortex-M target (`mps2-an385` etc.) or Renode is on the roadmap but not in the current release.
+- **SBOM returns empty for RTOS.** A v2 binary-symbol-pattern matcher against a known-component database is the planned path.
+- **One kind per project.** Mixed-kind firmware (one device, two MCUs running different OSes) needs per-firmware kind storage and a UX for switching the active one. Today the model is single-kind; the dropdown on the project page changes the project-wide classification.
+- **Vendor OTA wrappers.** Detection runs after binwalk has stripped standard container formats. Some vendors use proprietary OTA framing that binwalk doesn't unwrap; in those cases you'll either need to pre-strip the wrapper or use the manual kind override.

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,6 +48,10 @@ WAIRZ works with any MCP-compatible AI agent — Claude Code, Claude Desktop, Op
 
     AFL++ with QEMU mode for cross-architecture binary fuzzing, with automatic dictionary/corpus generation and crash triage.
 
+- :material-chip: **RTOS Support**
+
+    Auto-classifies firmware as Linux / FreeRTOS / Zephyr / baremetal Cortex-M on unpack. RTOS projects get a dedicated tool category for vector tables, task enumeration, base-address recovery, and memory maps.
+
 - :material-compare: **Firmware Comparison**
 
     Diff filesystem trees, binaries, and decompiled functions across firmware versions for patch analysis.
@@ -71,7 +75,7 @@ WAIRZ works with any MCP-compatible AI agent — Claude Code, Claude Desktop, Op
 !!! warning "Public Beta"
     WAIRZ is currently in **public beta**. You may encounter bugs or rough edges. If you run into any issues, please [open an issue on GitHub](https://github.com/digitalandrew/wairz/issues) or reach out at andrew@digitalandrew.io.
 
-    WAIRZ is currently designed for **embedded Linux** firmware samples. Support for RTOS and bare-metal firmware is planned for future releases.
+    WAIRZ supports **embedded Linux**, **FreeRTOS**, **Zephyr**, and **baremetal Cortex-M** firmware. Auto-detection runs on unpack and can be overridden from the project page. See [RTOS Support](features/rtos.md) for details.
 
 ---
 

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -1,6 +1,14 @@
 # MCP Tools Reference
 
-Wairz exposes 60+ tools to Claude via the Model Context Protocol. This page lists all available tools organized by category.
+Wairz exposes 90+ tools to Claude via the Model Context Protocol. This page lists all available tools organized by category.
+
+!!! note "Tool visibility is firmware-kind aware"
+    Some tools only apply to certain firmware kinds (Linux vs RTOS). When you `switch_project`, the MCP server emits `notifications/tools/list_changed` and the client refreshes its tool list automatically:
+
+    - **Linux-only tools** (emulation, init-script analysis, setuid scanning, component map, etc.) are hidden when the active project's firmware is RTOS or unknown.
+    - **RTOS-only tools** (vector-table parsing, task enumeration, base-address recovery, memory map) are hidden when the active project is Linux.
+
+    Tools without an explicit kind tag apply to all firmware. The kind discriminator is described in [RTOS Support](features/rtos.md).
 
 ## Project
 
@@ -145,3 +153,15 @@ Wairz exposes 60+ tools to Claude via the Model Context Protocol. This page list
 | Tool | Description |
 |------|-------------|
 | `save_code_cleanup` | Save AI-cleaned decompiled code to the analysis cache |
+
+## RTOS Analysis
+
+Available only when the active project's firmware kind is `rtos`. Operate on the firmware blob (`.axf` / `.elf` / `.bin`) at `/firmware/<basename>` rather than an unpacked rootfs.
+
+| Tool | Description |
+|------|-------------|
+| `detect_rtos_kernel` | Re-run RTOS detection and return the kind, flavor, evidence, and ELF metadata |
+| `enumerate_rtos_tasks` | Scan `.symtab` for likely task entry-point functions and FreeRTOS / kernel infrastructure symbols (requires unstripped ELF) |
+| `analyze_vector_table` | Parse the ARM Cortex-M vector table from `.isr_vector` / first executable LOAD segment / file offset 0, with handler-symbol resolution |
+| `recover_base_address` | Return LOAD-segment vaddr/paddr for ELFs, or infer a flash base from the reset vector for raw `.bin` |
+| `analyze_memory_map` | Classify allocated sections into flash (executable / read-only) vs RAM (writable) for Ghidra/IDA loader setup or QEMU memory maps |

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import SbomPage from '@/pages/SbomPage'
 import EmulationPage from '@/pages/EmulationPage'
 import FuzzingPage from '@/pages/FuzzingPage'
 import ComparisonPage from '@/pages/ComparisonPage'
+import RTOSAnalysisPage from '@/pages/RTOSAnalysisPage'
 import HelpPage from '@/pages/HelpPage'
 import NotFoundPage from '@/pages/NotFoundPage'
 
@@ -29,6 +30,7 @@ export default function App() {
           <Route path="/projects/:projectId/emulation" element={<EmulationPage />} />
           <Route path="/projects/:projectId/fuzzing" element={<FuzzingPage />} />
           <Route path="/projects/:projectId/compare" element={<ComparisonPage />} />
+          <Route path="/projects/:projectId/rtos" element={<RTOSAnalysisPage />} />
           <Route path="/help" element={<HelpPage />} />
           <Route path="*" element={<NotFoundPage />} />
         </Route>

--- a/frontend/src/api/firmware.ts
+++ b/frontend/src/api/firmware.ts
@@ -1,5 +1,11 @@
 import apiClient from './client'
-import type { FirmwareDetail, FirmwareMetadata, FirmwareSummary } from '@/types'
+import type {
+  FirmwareDetail,
+  FirmwareKind,
+  FirmwareMetadata,
+  FirmwareSummary,
+  RtosFlavor,
+} from '@/types'
 
 export async function uploadFirmware(
   projectId: string,
@@ -64,6 +70,19 @@ export async function deleteFirmware(
   firmwareId: string,
 ): Promise<void> {
   await apiClient.delete(`/projects/${projectId}/firmware/${firmwareId}`)
+}
+
+export async function updateFirmwareKind(
+  projectId: string,
+  firmwareId: string,
+  kind: FirmwareKind,
+  rtosFlavor: RtosFlavor | null = null,
+): Promise<FirmwareDetail> {
+  const { data } = await apiClient.patch<FirmwareDetail>(
+    `/projects/${projectId}/firmware/${firmwareId}/kind`,
+    { kind, rtos_flavor: rtosFlavor },
+  )
+  return data
 }
 
 export async function unpackFirmware(

--- a/frontend/src/components/explorer/FileTree.tsx
+++ b/frontend/src/components/explorer/FileTree.tsx
@@ -7,6 +7,7 @@ import {
   isPlaceholder,
   type TreeNode,
 } from '@/stores/explorerStore'
+import { useProjectStore } from '@/stores/projectStore'
 import { getFileIcon } from '@/utils/fileIcons'
 import { formatFileSize } from '@/utils/format'
 
@@ -93,6 +94,14 @@ export default function FileTree() {
   const [newNoteTitle, setNewNoteTitle] = useState('')
   const newNoteInputRef = useRef<HTMLInputElement>(null)
 
+  // Documents-only mode: skip the firmware filesystem pane when the
+  // project doesn't have a Linux rootfs to walk (RTOS / unknown / no
+  // firmware uploaded yet).
+  const project = useProjectStore((s) =>
+    projectId ? s.projects.find((p) => p.id === projectId) : undefined,
+  )
+  const hasFirmwareFs = project?.firmware_kind === 'linux'
+
   const containerRef = useRef<HTMLDivElement>(null)
   const treeRef = useRef<TreeApi<TreeNode>>(null)
   const [height, setHeight] = useState(400)
@@ -112,10 +121,12 @@ export default function FileTree() {
     return () => observer.disconnect()
   }, [])
 
-  // Load root on mount
+  // Load firmware filesystem root on mount — only when there is one to
+  // load. RTOS / unknown projects skip this so listDirectory doesn't
+  // error out against an empty extracted_path.
   useEffect(() => {
-    if (projectId) loadRootDirectory(projectId)
-  }, [projectId, loadRootDirectory])
+    if (projectId && hasFirmwareFs) loadRootDirectory(projectId)
+  }, [projectId, hasFirmwareFs, loadRootDirectory])
 
   // Update visible node count for dynamic tree height
   useEffect(() => {
@@ -269,39 +280,45 @@ export default function FileTree() {
     )
   }
 
-  // Size tree to its content, capped at available space
+  // Size tree to its content, capped at available space. When the firmware
+  // filesystem is hidden (RTOS / unknown), the documents section gets the
+  // full pane.
   const newNoteRowHeight = showNewNote ? 32 : 0
-  const docsHeight = documents.length > 0 || showNewNote || documentsLoading
-    ? Math.min(documents.length * 28 + 36 + newNoteRowHeight, 220)
-    : 36
+  const docsHeight = !hasFirmwareFs
+    ? height
+    : documents.length > 0 || showNewNote || documentsLoading
+      ? Math.min(documents.length * 28 + 36 + newNoteRowHeight, 220)
+      : 36
   const maxTreeHeight = Math.max(height - docsHeight, 100)
   const contentHeight = visibleCount * 28
   const treeHeight = visibleCount > 0 ? Math.min(contentHeight, maxTreeHeight) : maxTreeHeight
 
   return (
     <div ref={containerRef} className="relative flex-1 overflow-hidden" onContextMenu={handleContextMenu}>
-      <div style={{ height: treeHeight }}>
-        <Tree<TreeNode>
-          ref={treeRef}
-          data={treeData}
-          width="100%"
-          height={treeHeight}
-          rowHeight={28}
-          indent={16}
-          openByDefault={false}
-          disableDrag
-          disableDrop
-          disableEdit
-          disableMultiSelection
-          onToggle={handleToggle}
-          onActivate={handleActivate}
-        >
-          {Node}
-        </Tree>
-      </div>
+      {hasFirmwareFs && (
+        <div style={{ height: treeHeight }}>
+          <Tree<TreeNode>
+            ref={treeRef}
+            data={treeData}
+            width="100%"
+            height={treeHeight}
+            rowHeight={28}
+            indent={16}
+            openByDefault={false}
+            disableDrag
+            disableDrop
+            disableEdit
+            disableMultiSelection
+            onToggle={handleToggle}
+            onActivate={handleActivate}
+          >
+            {Node}
+          </Tree>
+        </div>
+      )}
 
       {/* Project Documents section */}
-      <div className="border-t border-border">
+      <div className={hasFirmwareFs ? 'border-t border-border' : ''}>
           <div className="flex items-center gap-2 px-4 py-1.5 text-xs font-medium text-muted-foreground">
             <FileText className="h-3.5 w-3.5" />
             Documents

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -13,27 +13,49 @@ import {
   Bug,
   GitCompareArrows,
   HelpCircle,
+  Cpu,
 } from 'lucide-react'
 import { Separator } from '@/components/ui/separator'
 import wairzLogo from '@/assets/wairz_full_logo.png'
 import wairzIcon from '@/assets/wairz_logo.png'
 import { useProjectStore } from '@/stores/projectStore'
+import type { FirmwareKind } from '@/types'
 
 interface SidebarProps {
   collapsed: boolean
   onToggle: () => void
 }
 
-const projectSubPages = [
-  { suffix: '', label: 'Overview', icon: LayoutDashboard },
-  { suffix: '/explore', label: 'File Explorer', icon: FolderSearch },
-  { suffix: '/findings', label: 'Findings', icon: ShieldAlert },
-  { suffix: '/map', label: 'Component Map', icon: Network },
-  { suffix: '/sbom', label: 'SBOM', icon: Package },
-  { suffix: '/emulation', label: 'Emulation (experimental)', icon: PlayCircle },
-  { suffix: '/fuzzing', label: 'Fuzzing (experimental)', icon: Bug },
-  { suffix: '/compare', label: 'Compare', icon: GitCompareArrows },
+interface SubPage {
+  suffix: string
+  label: string
+  icon: typeof LayoutDashboard
+  // Which firmware kinds expose this tab. Tabs not listed for a kind are
+  // hidden from the sidebar — most analysis pages are Linux-only because
+  // they assume a mountable rootfs.
+  kinds: ReadonlyArray<FirmwareKind | 'no-firmware'>
+}
+
+const ALL_KINDS = ['linux', 'rtos', 'unknown', 'no-firmware'] as const
+
+const projectSubPages: ReadonlyArray<SubPage> = [
+  { suffix: '', label: 'Overview', icon: LayoutDashboard, kinds: ALL_KINDS },
+  { suffix: '/explore', label: 'File Explorer', icon: FolderSearch, kinds: ['linux'] },
+  { suffix: '/rtos', label: 'RTOS Analysis', icon: Cpu, kinds: ['rtos'] },
+  { suffix: '/findings', label: 'Findings', icon: ShieldAlert, kinds: ALL_KINDS },
+  { suffix: '/map', label: 'Component Map', icon: Network, kinds: ['linux'] },
+  { suffix: '/sbom', label: 'SBOM', icon: Package, kinds: ['linux'] },
+  { suffix: '/emulation', label: 'Emulation (experimental)', icon: PlayCircle, kinds: ['linux'] },
+  { suffix: '/fuzzing', label: 'Fuzzing (experimental)', icon: Bug, kinds: ['linux'] },
+  { suffix: '/compare', label: 'Compare', icon: GitCompareArrows, kinds: ['linux'] },
 ]
+
+function subPagesFor(kind: FirmwareKind | null): ReadonlyArray<SubPage> {
+  // Projects without firmware get the same tab set as 'unknown' — only
+  // the overview makes sense before upload.
+  const effective: FirmwareKind | 'no-firmware' = kind ?? 'no-firmware'
+  return projectSubPages.filter((p) => p.kinds.includes(effective))
+}
 
 export default function Sidebar({ collapsed, onToggle }: SidebarProps) {
   const { projectId: activeProjectId } = useParams<{ projectId: string }>()
@@ -170,7 +192,7 @@ export default function Sidebar({ collapsed, onToggle }: SidebarProps) {
               {/* Sub-pages */}
               {isExpanded && (
                 <div className="ml-3 border-l border-border/50 pl-2">
-                  {projectSubPages.map((page) => (
+                  {subPagesFor(project.firmware_kind).map((page) => (
                     <NavLink
                       key={page.suffix}
                       to={`/projects/${project.id}${page.suffix}`}

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -28,7 +28,7 @@ interface SidebarProps {
 
 interface SubPage {
   suffix: string
-  label: string
+  label: string | ((kind: FirmwareKind | 'no-firmware') => string)
   icon: typeof LayoutDashboard
   // Which firmware kinds expose this tab. Tabs not listed for a kind are
   // hidden from the sidebar — most analysis pages are Linux-only because
@@ -40,7 +40,14 @@ const ALL_KINDS = ['linux', 'rtos', 'unknown', 'no-firmware'] as const
 
 const projectSubPages: ReadonlyArray<SubPage> = [
   { suffix: '', label: 'Overview', icon: LayoutDashboard, kinds: ALL_KINDS },
-  { suffix: '/explore', label: 'File Explorer', icon: FolderSearch, kinds: ['linux'] },
+  {
+    suffix: '/explore',
+    // Linux projects browse the firmware rootfs + project documents;
+    // RTOS / unknown / no-firmware only have project documents to edit.
+    label: (kind) => (kind === 'linux' ? 'File Explorer' : 'Project Files'),
+    icon: FolderSearch,
+    kinds: ALL_KINDS,
+  },
   { suffix: '/rtos', label: 'RTOS Analysis', icon: Cpu, kinds: ['rtos'] },
   { suffix: '/findings', label: 'Findings', icon: ShieldAlert, kinds: ALL_KINDS },
   { suffix: '/map', label: 'Component Map', icon: Network, kinds: ['linux'] },
@@ -50,11 +57,23 @@ const projectSubPages: ReadonlyArray<SubPage> = [
   { suffix: '/compare', label: 'Compare', icon: GitCompareArrows, kinds: ['linux'] },
 ]
 
-function subPagesFor(kind: FirmwareKind | null): ReadonlyArray<SubPage> {
+interface ResolvedSubPage {
+  suffix: string
+  label: string
+  icon: typeof LayoutDashboard
+}
+
+function subPagesFor(kind: FirmwareKind | null): ResolvedSubPage[] {
   // Projects without firmware get the same tab set as 'unknown' — only
-  // the overview makes sense before upload.
+  // overview / findings / project-files make sense before upload.
   const effective: FirmwareKind | 'no-firmware' = kind ?? 'no-firmware'
-  return projectSubPages.filter((p) => p.kinds.includes(effective))
+  return projectSubPages
+    .filter((p) => p.kinds.includes(effective))
+    .map((p) => ({
+      suffix: p.suffix,
+      label: typeof p.label === 'function' ? p.label(effective) : p.label,
+      icon: p.icon,
+    }))
 }
 
 export default function Sidebar({ collapsed, onToggle }: SidebarProps) {

--- a/frontend/src/pages/HelpPage.tsx
+++ b/frontend/src/pages/HelpPage.tsx
@@ -122,6 +122,66 @@ export default function HelpPage() {
           </ul>
         </Section>
 
+        <Section title="Firmware Kind (Linux vs RTOS)">
+          <p className="mb-3">
+            Wairz classifies every uploaded firmware as <strong>linux</strong>,{' '}
+            <strong>rtos</strong>, or <strong>unknown</strong>. The kind drives
+            which analysis tabs and AI tools are exposed for that project.
+          </p>
+          <ul className="list-inside list-disc space-y-1">
+            <li>
+              <strong>Auto-detection:</strong> Runs on unpack. If a Linux
+              filesystem root is found, the project is{' '}
+              <em>linux</em>; otherwise the firmware blob is scanned for
+              FreeRTOS / Zephyr string markers and a Cortex-M vector-table
+              shape, and tagged <em>rtos</em> with a flavor (
+              <em>freertos</em>, <em>zephyr</em>, or{' '}
+              <em>baremetal-cortexm</em>) when matched.
+            </li>
+            <li>
+              <strong>Manual override:</strong> Use the kind dropdown next to
+              each firmware card on the project page to pin the kind. Manual
+              choices stick — re-detection on subsequent unpacks won't
+              overwrite them.
+            </li>
+            <li>
+              <strong>RTOS sidebar:</strong> RTOS projects see a slimmer tab
+              set: Overview, Project Files (documents only), RTOS Analysis,
+              and Findings. Linux-rootfs-specific tabs (Component Map, SBOM,
+              Emulation, Fuzzing, Compare) are hidden.
+            </li>
+            <li>
+              <strong>RTOS MCP tools:</strong> The AI assistant gets a
+              dedicated RTOS tool category for{' '}
+              <code className="rounded bg-muted px-1 py-0.5 text-xs">
+                detect_rtos_kernel
+              </code>
+              ,{' '}
+              <code className="rounded bg-muted px-1 py-0.5 text-xs">
+                enumerate_rtos_tasks
+              </code>
+              ,{' '}
+              <code className="rounded bg-muted px-1 py-0.5 text-xs">
+                analyze_vector_table
+              </code>
+              ,{' '}
+              <code className="rounded bg-muted px-1 py-0.5 text-xs">
+                recover_base_address
+              </code>
+              , and{' '}
+              <code className="rounded bg-muted px-1 py-0.5 text-xs">
+                analyze_memory_map
+              </code>
+              . Generic binary tools also work — they read the firmware blob
+              from{' '}
+              <code className="rounded bg-muted px-1 py-0.5 text-xs">
+                /firmware/&lt;basename&gt;
+              </code>{' '}
+              when there is no rootfs to mount.
+            </li>
+          </ul>
+        </Section>
+
         <Section title="Project Documents">
           <p className="mb-3">
             Attach reference documents and notes to your project for context

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -19,14 +19,29 @@ import {
   Pencil,
   Check,
   X,
+  ChevronDown,
 } from 'lucide-react'
 import { useProjectStore } from '@/stores/projectStore'
-import { listFirmware, deleteFirmware, updateFirmware, uploadRootfs } from '@/api/firmware'
-import type { FirmwareDetail } from '@/types'
+import {
+  listFirmware,
+  deleteFirmware,
+  updateFirmware,
+  updateFirmwareKind,
+  uploadRootfs,
+} from '@/api/firmware'
+import type { FirmwareDetail, FirmwareKind, RtosFlavor } from '@/types'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
 import { formatFileSize, formatDate } from '@/utils/format'
 import FirmwareUpload from '@/components/projects/FirmwareUpload'
 import FirmwareMetadataCard from '@/components/projects/FirmwareMetadataCard'
@@ -39,6 +54,17 @@ const STATUS_VARIANT: Record<string, 'default' | 'secondary' | 'destructive' | '
   unpacking: 'secondary',
   error: 'destructive',
   created: 'outline',
+}
+
+function formatKind(kind: FirmwareKind | undefined, flavor: RtosFlavor | null | undefined): string {
+  if (kind === 'rtos') {
+    if (flavor === 'freertos') return 'RTOS · FreeRTOS'
+    if (flavor === 'zephyr') return 'RTOS · Zephyr'
+    if (flavor === 'baremetal-cortexm') return 'Bare-metal Cortex-M'
+    return 'RTOS'
+  }
+  if (kind === 'linux') return 'Linux'
+  return 'Unknown'
 }
 
 export default function ProjectDetailPage() {
@@ -174,6 +200,21 @@ export default function ProjectDetailPage() {
       // error handled by caller
     }
     setEditingVersionLabel(null)
+  }
+
+  const handleKindChange = async (
+    firmwareId: string,
+    kind: FirmwareKind,
+    flavor: RtosFlavor | null,
+  ) => {
+    if (!projectId) return
+    try {
+      await updateFirmwareKind(projectId, firmwareId, kind, flavor)
+      fetchProject(projectId)
+      listFirmware(projectId).then(setFirmwareList).catch(() => {})
+    } catch {
+      // error surfacing handled at a higher level if needed
+    }
   }
 
   const handleRootfsUpload = async (firmwareId: string, file: File) => {
@@ -315,6 +356,39 @@ export default function ProjectDetailPage() {
                       {isUnpacked && (
                         <Badge variant="default" className="text-xs">unpacked</Badge>
                       )}
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <Badge
+                            variant="outline"
+                            className="text-xs cursor-pointer hover:bg-secondary/50"
+                          >
+                            {formatKind(fw.firmware_kind, fw.rtos_flavor)}
+                            <ChevronDown className="ml-1 h-2.5 w-2.5 opacity-60" />
+                          </Badge>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="start">
+                          <DropdownMenuLabel className="text-xs font-normal text-muted-foreground">
+                            Kind ({fw.firmware_kind_source ?? 'unset'})
+                          </DropdownMenuLabel>
+                          <DropdownMenuSeparator />
+                          <DropdownMenuItem onClick={() => handleKindChange(fw.id, 'linux', null)}>
+                            Linux
+                          </DropdownMenuItem>
+                          <DropdownMenuItem onClick={() => handleKindChange(fw.id, 'rtos', 'freertos')}>
+                            RTOS · FreeRTOS
+                          </DropdownMenuItem>
+                          <DropdownMenuItem onClick={() => handleKindChange(fw.id, 'rtos', 'zephyr')}>
+                            RTOS · Zephyr
+                          </DropdownMenuItem>
+                          <DropdownMenuItem onClick={() => handleKindChange(fw.id, 'rtos', 'baremetal-cortexm')}>
+                            Bare-metal Cortex-M
+                          </DropdownMenuItem>
+                          <DropdownMenuSeparator />
+                          <DropdownMenuItem onClick={() => handleKindChange(fw.id, 'unknown', null)}>
+                            Unknown
+                          </DropdownMenuItem>
+                        </DropdownMenuContent>
+                      </DropdownMenu>
                     </CardTitle>
                     <div className="flex gap-1">
                       {!isUnpacked && !hasError && (

--- a/frontend/src/pages/RTOSAnalysisPage.tsx
+++ b/frontend/src/pages/RTOSAnalysisPage.tsx
@@ -1,0 +1,212 @@
+import { useEffect, useState } from 'react'
+import { useParams } from 'react-router-dom'
+import { Cpu, Loader2, AlertCircle, FileCode, Hash, Terminal } from 'lucide-react'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { listFirmware } from '@/api/firmware'
+import { formatFileSize } from '@/utils/format'
+import type { FirmwareDetail } from '@/types'
+
+interface RtosTool {
+  name: string
+  description: string
+}
+
+const RTOS_TOOLS: RtosTool[] = [
+  {
+    name: 'detect_rtos_kernel',
+    description:
+      'Re-run RTOS detection and report the matching evidence plus ELF metadata.',
+  },
+  {
+    name: 'enumerate_rtos_tasks',
+    description:
+      'List likely task entry-point functions and FreeRTOS infrastructure symbols (requires unstripped ELF).',
+  },
+  {
+    name: 'analyze_vector_table',
+    description:
+      'Parse the Cortex-M vector table from .isr_vector or first executable segment, with handler symbols.',
+  },
+  {
+    name: 'recover_base_address',
+    description:
+      'Return LOAD-segment vaddr/paddr for ELFs, or infer a flash base from the reset vector for raw .bin.',
+  },
+  {
+    name: 'analyze_memory_map',
+    description:
+      'Classify allocated sections into flash (executable / read-only) vs RAM (writable).',
+  },
+]
+
+function flavorLabel(flavor: FirmwareDetail['rtos_flavor']): string {
+  switch (flavor) {
+    case 'freertos':
+      return 'FreeRTOS'
+    case 'zephyr':
+      return 'Zephyr'
+    case 'baremetal-cortexm':
+      return 'Baremetal Cortex-M'
+    default:
+      return 'RTOS'
+  }
+}
+
+export default function RTOSAnalysisPage() {
+  const { projectId } = useParams<{ projectId: string }>()
+  const [firmware, setFirmware] = useState<FirmwareDetail | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!projectId) return
+    let cancelled = false
+    setLoading(true)
+    setError(null)
+    listFirmware(projectId)
+      .then((items) => {
+        if (cancelled) return
+        // Match the MCP server's "active firmware" rule — most recent upload.
+        const active = items
+          .slice()
+          .sort((a, b) => b.created_at.localeCompare(a.created_at))[0]
+        setFirmware(active ?? null)
+      })
+      .catch((e) => {
+        if (!cancelled) {
+          setError(e?.response?.data?.detail || e.message || 'Failed to load firmware')
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [projectId])
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-16">
+        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="rounded border border-destructive/20 bg-destructive/10 p-4 text-sm text-destructive">
+        <AlertCircle className="mr-2 inline h-4 w-4" />
+        {error}
+      </div>
+    )
+  }
+
+  if (!firmware) {
+    return (
+      <div className="rounded border border-border bg-muted/30 p-6 text-sm text-muted-foreground">
+        No firmware uploaded yet for this project.
+      </div>
+    )
+  }
+
+  const isRtos = firmware.firmware_kind === 'rtos'
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="flex items-center gap-2 text-2xl font-semibold tracking-tight">
+            <Cpu className="h-5 w-5" />
+            RTOS Analysis
+          </h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Single-binary firmware analysis. Use the MCP tools below to inspect the image.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Badge variant="secondary">{flavorLabel(firmware.rtos_flavor)}</Badge>
+          {firmware.architecture && (
+            <Badge variant="outline">{firmware.architecture}</Badge>
+          )}
+          {firmware.endianness && (
+            <Badge variant="outline">{firmware.endianness}-endian</Badge>
+          )}
+        </div>
+      </div>
+
+      {!isRtos && (
+        <div className="rounded border border-amber-500/30 bg-amber-500/10 p-3 text-sm">
+          This project's firmware is currently classified as
+          <span className="mx-1 font-semibold">{firmware.firmware_kind}</span>
+          rather than <span className="font-semibold">rtos</span>. RTOS-specific
+          MCP tools won't be exposed until you change the kind on the project
+          overview page.
+        </div>
+      )}
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-base">
+            <FileCode className="h-4 w-4" />
+            Firmware
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2 text-sm">
+          <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+            <div>
+              <div className="text-muted-foreground">Filename</div>
+              <div className="font-mono">{firmware.original_filename ?? '(unknown)'}</div>
+            </div>
+            <div>
+              <div className="text-muted-foreground">Size</div>
+              <div>{firmware.file_size != null ? formatFileSize(firmware.file_size) : '?'}</div>
+            </div>
+            <div className="sm:col-span-2">
+              <div className="text-muted-foreground">SHA-256</div>
+              <div className="break-all font-mono text-xs">
+                <Hash className="mr-1 inline h-3 w-3" />
+                {firmware.sha256}
+              </div>
+            </div>
+            <div>
+              <div className="text-muted-foreground">Detection source</div>
+              <div>{firmware.firmware_kind_source ?? '—'}</div>
+            </div>
+            <div>
+              <div className="text-muted-foreground">OS info</div>
+              <div className="font-mono text-xs">{firmware.os_info?.trim() || '—'}</div>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-base">
+            <Terminal className="h-4 w-4" />
+            MCP tools for this firmware
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="mb-3 text-sm text-muted-foreground">
+            These tools operate on the firmware blob via the Wairz MCP server.
+            Connect from Claude Code or Claude Desktop and invoke them by name.
+          </p>
+          <ul className="space-y-2 text-sm">
+            {RTOS_TOOLS.map((tool) => (
+              <li
+                key={tool.name}
+                className="rounded border border-border bg-muted/20 px-3 py-2"
+              >
+                <code className="font-mono text-xs font-semibold">{tool.name}</code>
+                <p className="mt-1 text-xs text-muted-foreground">{tool.description}</p>
+              </li>
+            ))}
+          </ul>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -11,6 +11,10 @@ export interface ProjectDetail extends Project {
   firmware: FirmwareSummary[]
 }
 
+export type FirmwareKind = 'linux' | 'rtos' | 'unknown'
+export type FirmwareKindSource = 'detected' | 'manual'
+export type RtosFlavor = 'freertos' | 'zephyr' | 'baremetal-cortexm'
+
 export interface FirmwareSummary {
   id: string
   original_filename: string | null
@@ -21,6 +25,9 @@ export interface FirmwareSummary {
   os_info: string | null
   kernel_path: string | null
   version_label: string | null
+  firmware_kind: FirmwareKind
+  firmware_kind_source: FirmwareKindSource | null
+  rtos_flavor: RtosFlavor | null
   created_at: string
 }
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -5,6 +5,8 @@ export interface Project {
   status: string
   created_at: string
   updated_at: string
+  firmware_kind: FirmwareKind | null
+  rtos_flavor: RtosFlavor | null
 }
 
 export interface ProjectDetail extends Project {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,6 +53,7 @@ nav:
     - Connecting AI (MCP): getting-started/mcp-setup.md
   - Features:
     - File Explorer: features/file-explorer.md
+    - RTOS Support: features/rtos.md
     - Binary Analysis: features/binary-analysis.md
     - Security Assessment: features/security-assessment.md
     - SBOM & CVE Scanning: features/sbom.md


### PR DESCRIPTION
## Summary

Wairz was Linux-only. This branch adds first-class support for RTOS firmware (FreeRTOS, Zephyr, baremetal Cortex-M) end-to-end: data model, MCP capability tagging, kind-aware system prompt, auto-detection on unpack, RTOS-specific MCP tool category, and a kind-aware UI. All filed under one project — no fork.

The design choice was a single `Project` model with a `firmware_kind` discriminator (`linux | rtos | unknown`) rather than parallel models. ~70% of existing tooling stays applicable; only Linux-rootfs-specific tools (emulation, init-script analysis, setuid scanning, component map, SBOM, fuzzing harnesses) are tagged Linux-only and disappear from the agent's tool set when an RTOS project is active.

## What's in the branch (8 commits)

**Phase 1 — data model** (`84444ea`)  
`firmware_kind`, `firmware_kind_source`, `rtos_flavor` columns on the firmware table (Alembic migration backfills existing rows to `linux` / `detected`). New `PATCH /firmware/{id}/kind` endpoint for the manual-override dropdown on the project page.

**Phase 2 — capability-tagged MCP tools** (`84444ea`)  
`ToolDefinition.applies_to: tuple[str, ...]` defaults to all kinds. Per-tool tagging only on clearly kind-specific handlers (15 emulation tools, 4 Linux security tools, 1 filesystem tool). Defense-in-depth in the MCP server: dynamic filter in `list_tools` AND a reject in `call_tool` so stale client tool lists fail safely.

**Phase 3 — kind-aware system prompt** (`d4137c4`)  
`build_system_prompt` now takes `firmware_kind` / `rtos_flavor`. RTOS projects get an RTOS knowledge block (FreeRTOS task model, Zephyr kernel symbols, Cortex-M conventions) and a short emulation note instead of the full QEMU troubleshooting section. ~11 KB → ~8.6 KB on RTOS sessions.

**Phase 4 — auto-detection on unpack** (`019141c`)  
New `app/services/rtos_detection_service.py`: weighted byte-marker scanner for FreeRTOS (`xTaskCreate`/`pxCurrentTCB`/`vTaskStartScheduler`), Zephyr (`Booting Zephyr OS`/`ZEPHYR_BASE`), and a Cortex-M vector-table heuristic (initial-SP-in-SRAM + thumb-bit-set reset handler in flash). Hooked into `unpack_firmware`; respects manual override (only writes when `firmware_kind_source != 'manual'`).

**Phase 5 — RTOS MCP tool category** (`149d4c0`)  
`app/ai/tools/rtos.py` with five tools, all `applies_to=("rtos",)`:
- `detect_rtos_kernel` — re-runs detection + reports evidence
- `enumerate_rtos_tasks` — `.symtab` scan for task entry-points / FreeRTOS infrastructure
- `analyze_vector_table` — Cortex-M vector parsing with handler-symbol resolution
- `recover_base_address` — LOAD-segment vaddr/paddr or raw-blob reset-vector inference
- `analyze_memory_map` — flash (X / R) vs RAM (W) section classification

`ProjectState` and `ToolContext` carry `storage_path` so RTOS tools see the firmware blob (no rootfs to mount).

**Phase 6 — kind-aware UI** (`a011941`)  
`firmware_kind` / `rtos_flavor` surfaced on `ProjectListResponse` and `ProjectResponse` (computed via `model_validator` from the most recent firmware). Sidebar filters analysis tabs by kind; new `RTOSAnalysisPage` at `/projects/:id/rtos` summarises ELF metadata + the five RTOS MCP tools.

**Follow-up: project-files explorer for non-Linux** (`409ec6e`)  
Phase 6 hid `/explore` from RTOS projects, which incidentally hid the only UI for editing `WAIRZ.md` / `SCRATCHPAD.md`. Re-enabled for all kinds (relabelled "Project Files" when there's no rootfs); `FileTree` skips the firmware tree pane in that case so the documents section gets the full sidebar.

**Follow-up: MCP loadable + tool-list refresh + virtual `/firmware/`** (`3f48b95`, `5dbc1a3`)  
Discovered live during a real assessment:
1. The MCP firmware-selection logic was still gating on `extracted_path`, so a successfully classified RTOS image showed up as "no firmware loaded". Now treats `kind=='rtos' && storage_path` as loadable.
2. The 5 RTOS-only tools never appeared because `list_tools` is computed at MCP startup. Server now advertises `tools.listChanged` and emits `notifications/tools/list_changed` from `switch_project` whenever the active firmware kind changes.
3. Generic binary tools (`extract_strings`, `get_binary_info`, `decompile_function`, etc.) sandbox against `extracted_path`, which is empty for RTOS. `FileService` now accepts `firmware_path` and exposes `/firmware/<basename>`. Blob-only mode also accepts `/<basename>` and bare `<basename>` for forgiving callers; path-traversal protections preserved.

## Test plan

### Backend
- [x] `py_compile` clean across all changed modules
- [x] 9-case unit smoke-test of `rtos_detection_service` (linux short-circuit, FreeRTOS strong+weak, Zephyr, Cortex-M raw STM32, garbage rejection, thumb-bit-clear rejection, etc.)
- [x] `FileService` resolver smoke-test across blob-only / linux+firmware / legacy-linux modes
- [x] Alembic migration verified by inspecting `firmware` table columns post-up
- [x] Live end-to-end on `bodyscan_scale` (a real FreeRTOS .axf): unpack auto-detects `kind=rtos, flavor=freertos, source=detected`, MCP loads the project, all five RTOS-only tools appear in the tool list after `switch_project`, generic binary tools (`get_binary_info`, `list_functions`, `decompile_function`) work via `/firmware/<basename>`

### Frontend
- [x] `tsc -b && vite build` passes (Docker build runs both)
- [x] Manual: kind dropdown override on project page wires through PATCH endpoint
- [x] Manual: sidebar shows the right tab subset per kind
  - linux: full set (8 tabs)
  - rtos: Overview / Project Files / RTOS Analysis / Findings (4 tabs)
  - unknown / no-firmware: Overview / Project Files / Findings (3 tabs)
- [x] Manual: `RTOSAnalysisPage` renders ELF metadata + MCP tool list
- [x] Manual: `Project Files` explorer correctly degrades to documents-only for RTOS

### Real-world validation
A full RTOS security assessment was run end-to-end against a Wyze Scale BodyScan FreeRTOS firmware using only the tools added in this branch. Result: 9 findings filed (2 critical / 4 high / 1 medium / 1 low / 1 info), four working PoC scripts saved as project documents, and a 14 KB physical-testing playbook. Both follow-up fixes (`3f48b95`, `5dbc1a3`) are direct results of gaps that surfaced during that assessment, so the branch has been hammered on its target workflow.

## Out of scope (deferred, for follow-up)

- **RTOS-aware emulation** (Renode / QEMU Cortex-M `mps2-an385` machine). Would let users actually boot RTOS images. Larger scope — own branch.
- **v2 binary-symbol SBOM** for RTOS (currently `generate_sbom` returns empty for RTOS). Needs a symbol-and-string-pattern matcher against a known-component DB.
- **Mixed-kind firmware** (one device, two MCUs running different OSes). Today the model is "one kind per project". Mixed support would need per-firmware kind plus a UX for switching the active one.
- **Vendor OTA wrappers** (Dialog DA1469x, Renesas, Realtek, etc.). Today RTOS detection runs on the inner ELF after binwalk strips the outer container; some vendors use proprietary OTA framing that binwalk doesn't unwrap.

## Compatibility

Existing Linux projects are unaffected — the migration backfills `firmware_kind = 'linux'`, the system prompt for kind=linux is unchanged, and no Linux MCP tool's behaviour or signature changed. The new fields are additive on every API response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)